### PR TITLE
introducing canaryd

### DIFF
--- a/cmd/canary/canary.go
+++ b/cmd/canary/canary.go
@@ -41,7 +41,10 @@ func main() {
 	go r.Start()
 
 	// fire up a sensor
-	s := canary.NewSensor(url, source)
+	site := &canary.Site{
+		URL: url,
+	}
+	s := canary.NewSensor(site, source)
 	go s.Start()
 
 	// move samples from the sensor to the reporter

--- a/cmd/canaryd/canaryd.go
+++ b/cmd/canaryd/canaryd.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/canaryio/canary"
+	"github.com/canaryio/canary/pkg/breadboard"
+)
+
+func getManifest(url string) (*canary.Manifest, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	m := &canary.Manifest{}
+	err = json.Unmarshal(body, m)
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+func main() {
+	manifestURL := os.Getenv("MANIFEST_URL")
+	if manifestURL == "" {
+		log.Fatal("MANIFEST_URL not set in ENV")
+	}
+
+	m, err := getManifest(manifestURL)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// source
+	source, err := os.Hostname()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// breadboard
+	b := breadboard.New(source)
+	go b.Start()
+	b.Update(m)
+
+	select {}
+}

--- a/manifest.go
+++ b/manifest.go
@@ -1,0 +1,22 @@
+package canary
+
+import "encoding/json"
+
+type Site struct {
+	URL  string `json:"url"`
+	Name string `json:"name"`
+}
+
+type Service struct {
+	Name   string          `json:"name"`
+	Config json.RawMessage `json:"config"`
+}
+
+type Manifest struct {
+	Sites    []*Site    `json:"sites"`
+	Services []*Service `json:"services"`
+}
+
+func GetManifest(url string) (*Manifest, error) {
+	return nil, nil
+}

--- a/pkg/breadboard/breadboard.go
+++ b/pkg/breadboard/breadboard.go
@@ -1,0 +1,89 @@
+package breadboard
+
+import (
+	"encoding/json"
+	"log"
+	"sync"
+
+	"github.com/canaryio/canary"
+	"github.com/canaryio/canary/pkg/libratoreporter"
+)
+
+// Breadboards wire everything together
+type Breadboard struct {
+	sync.Mutex
+	sensors   map[string]*canary.Sensor
+	reporters map[string]canary.Reporter
+	c         chan *canary.Sample
+	stop      chan int
+	source    string
+}
+
+func New(source string) *Breadboard {
+	return &Breadboard{
+		sensors:   make(map[string]*canary.Sensor),
+		reporters: make(map[string]canary.Reporter),
+		c:         make(chan *canary.Sample),
+		source:    source,
+		stop:      make(chan int),
+	}
+}
+
+func (b *Breadboard) Start() {
+	for {
+		select {
+		case <-b.stop:
+			for _, s := range b.sensors {
+				s.Stop()
+			}
+
+			for _, r := range b.reporters {
+				r.Stop()
+			}
+		case sample := <-b.c:
+			for _, r := range b.reporters {
+				r.Ingest(sample)
+			}
+		}
+	}
+}
+
+func (b *Breadboard) Stop() {
+	close(b.stop)
+}
+
+func (b *Breadboard) Update(m *canary.Manifest) error {
+	b.Lock()
+	defer b.Unlock()
+
+	// launch new sensors if they are not already running
+	for _, site := range m.Sites {
+		sensor := canary.NewSensor(site, b.source)
+		sensor.C = b.c
+		b.sensors[site.URL] = sensor
+		go sensor.Start()
+	}
+
+	// TODO: teardown old sensors
+
+	// launch new reporters if they are not already running
+	for _, service := range m.Services {
+		switch service.Name {
+		case "librato":
+			config := &libratoreporter.Config{}
+			err := json.Unmarshal(service.Config, config)
+			if err != nil {
+				return err
+			}
+			r := libratoreporter.New(config)
+			b.reporters[service.Name] = r
+			go r.Start()
+		default:
+			log.Printf("unknown service: %s", service.Name)
+		}
+	}
+
+	// TODO: teardown old reporters
+
+	return nil
+}

--- a/pkg/librato/librato.go
+++ b/pkg/librato/librato.go
@@ -1,0 +1,80 @@
+package librato
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type Gauge struct {
+	Name        string  `json:"name"`
+	MeasureTime int64   `json:"measure_time"`
+	Source      string  `json:"source"`
+	Count       int64   `json:"count"`
+	Sum         float64 `json:"sum"`
+	Min         float64 `json:"min",omitempty`
+	Max         float64 `json:"max",omitempty`
+	SumSquares  float64 `json:"max",omitempty`
+}
+
+type Payload struct {
+	Gauges []Gauge `json:"gauges"`
+}
+
+type Client struct {
+	sync.Mutex
+	User    string
+	Token   string
+	payload Payload
+}
+
+func (c *Client) AddGauge(g Gauge) {
+	c.Lock()
+	defer c.Unlock()
+	if g.MeasureTime == 0 {
+		g.MeasureTime = time.Now().Unix()
+	}
+	c.payload.Gauges = append(c.payload.Gauges, g)
+}
+
+func (c *Client) Flush() error {
+	c.Lock()
+	defer c.Unlock()
+
+	if len(c.payload.Gauges) == 0 {
+		return nil
+	}
+
+	b, err := json.Marshal(c.payload)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(
+		"POST",
+		"https://metrics-api.librato.com/v1/metrics",
+		bytes.NewBuffer(b),
+	)
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.SetBasicAuth(c.User, c.Token)
+
+	client := http.DefaultClient
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != 200 {
+		return fmt.Errorf("status code: %d\n", res.StatusCode)
+	}
+
+	c.payload = Payload{}
+
+	return nil
+}

--- a/pkg/libratoreporter/libratoreporter.go
+++ b/pkg/libratoreporter/libratoreporter.go
@@ -1,0 +1,136 @@
+package libratoreporter
+
+import (
+	"log"
+	"strings"
+	"time"
+
+	"github.com/canaryio/canary"
+	"github.com/canaryio/canary/pkg/librato"
+)
+
+type Reporter struct {
+	ingest chan *canary.Sample
+	stop   chan int
+	gauges map[string]*librato.Gauge
+	client *librato.Client
+}
+
+type Config struct {
+	User  string `json:"user"`
+	Token string `json:"token"`
+}
+
+func New(c *Config) *Reporter {
+	return &Reporter{
+		ingest: make(chan *canary.Sample),
+		stop:   make(chan int),
+		gauges: make(map[string]*librato.Gauge),
+		client: &librato.Client{
+			User:  c.User,
+			Token: c.Token,
+		},
+	}
+}
+
+func (r *Reporter) Start() {
+	t := time.NewTicker(5 * time.Second)
+	for {
+		select {
+		case <-r.stop:
+			break
+		case <-t.C:
+			r.flush()
+		case sample := <-r.ingest:
+			r.push(sample)
+		}
+	}
+}
+
+func (r *Reporter) Stop() {
+	close(r.stop)
+}
+
+func (r *Reporter) Ingest(s *canary.Sample) error {
+	r.ingest <- s
+	return nil
+}
+
+func (r *Reporter) push(s *canary.Sample) {
+	r.merge(LatencyGauge(s))
+	r.merge(HTTPErrorGauge(s))
+	r.merge(TransportErrorGauge(s))
+}
+
+func (r *Reporter) merge(g *librato.Gauge) {
+	og := r.gauges[g.Name]
+	if og == nil {
+		r.gauges[g.Name] = g
+		return
+	}
+
+	og.Count++
+	og.Sum += g.Sum
+	og.SumSquares += g.Sum * g.Sum
+
+	if g.Sum < og.Min {
+		og.Min = g.Sum
+	}
+
+	if g.Sum < og.Max {
+		og.Max = g.Sum
+	}
+}
+
+func (r *Reporter) flush() error {
+	for _, g := range r.gauges {
+		r.client.AddGauge(*g)
+	}
+	err := r.client.Flush()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	r.gauges = make(map[string]*librato.Gauge)
+	return nil
+}
+
+func LatencyGauge(s *canary.Sample) *librato.Gauge {
+	name := strings.Join([]string{s.Name, "latency"}, ".")
+	return &librato.Gauge{
+		Name:   name,
+		Source: s.Source,
+		Count:  1,
+		Sum:    s.TotalTime,
+	}
+}
+
+func HTTPErrorGauge(s *canary.Sample) *librato.Gauge {
+	name := strings.Join([]string{s.Name, "errors", "http"}, ".")
+	count := 0
+	if s.HTTPStatus > 399 {
+		count = 1
+	}
+
+	return &librato.Gauge{
+		Name:   name,
+		Source: s.Source,
+		Count:  int64(count),
+		Sum:    float64(count),
+	}
+}
+
+func TransportErrorGauge(s *canary.Sample) *librato.Gauge {
+	name := strings.Join([]string{s.Name, "errors", "transport"}, ".")
+	count := 0
+	if s.CurlStatus > 0 {
+		count = 1
+	}
+
+	return &librato.Gauge{
+		Name:   name,
+		Source: s.Source,
+		Count:  int64(count),
+		Sum:    float64(count),
+	}
+}

--- a/sampler.go
+++ b/sampler.go
@@ -8,6 +8,7 @@ import (
 
 type Sample struct {
 	URL               string
+	Name              string
 	T                 time.Time
 	Source            string
 	IP                string
@@ -29,11 +30,11 @@ func NewSampler() *Sampler {
 	}
 }
 
-func (s *Sampler) Sample(u, source string) *Sample {
+func (s *Sampler) Sample(site *Site, source string) *Sample {
 	defer s.easy.Reset()
 
 	// curl configuration
-	s.easy.Setopt(curl.OPT_URL, u)
+	s.easy.Setopt(curl.OPT_URL, site.URL)
 	noOut := func(buf []byte, userdata interface{}) bool {
 		return true
 	}
@@ -41,7 +42,8 @@ func (s *Sampler) Sample(u, source string) *Sample {
 	s.easy.Setopt(curl.OPT_TIMEOUT, 10)
 
 	sample := &Sample{
-		URL:    u,
+		URL:    site.URL,
+		Name:   site.Name,
 		Source: source,
 		T:      time.Now(),
 		IP:     "n/a",
@@ -62,16 +64,15 @@ func (s *Sampler) Sample(u, source string) *Sample {
 	sample.IP = ip.(string)
 
 	namelookupTime, _ := s.easy.Getinfo(curl.INFO_NAMELOOKUP_TIME)
-	sample.NameLookupTime = namelookupTime.(float64)
-
+	sample.NameLookupTime = namelookupTime.(float64) * 1000
 	connectTime, _ := s.easy.Getinfo(curl.INFO_CONNECT_TIME)
-	sample.ConnectTime = connectTime.(float64)
+	sample.ConnectTime = connectTime.(float64) * 1000
 
 	starttransferTime, _ := s.easy.Getinfo(curl.INFO_STARTTRANSFER_TIME)
-	sample.StartTransferTime = starttransferTime.(float64)
+	sample.StartTransferTime = starttransferTime.(float64) * 1000
 
 	totalTime, _ := s.easy.Getinfo(curl.INFO_TOTAL_TIME)
-	sample.TotalTime = totalTime.(float64)
+	sample.TotalTime = totalTime.(float64) * 1000
 
 	return sample
 }

--- a/sensor.go
+++ b/sensor.go
@@ -3,15 +3,15 @@ package canary
 import "time"
 
 type Sensor struct {
-	u    string
+	site *Site
 	l    string
 	C    chan *Sample
 	quit chan int
 }
 
-func NewSensor(u, l string) *Sensor {
+func NewSensor(site *Site, l string) *Sensor {
 	return &Sensor{
-		u:    u,
+		site: site,
 		l:    l,
 		quit: make(chan int),
 		C:    make(chan *Sample),
@@ -25,7 +25,7 @@ func (s *Sensor) Start() {
 	for {
 		select {
 		case <-t.C:
-			s.C <- sampler.Sample(s.u, s.l)
+			s.C <- sampler.Sample(s.site, s.l)
 		case <-s.quit:
 			break
 		}


### PR DESCRIPTION
canaryd is a standalone process, ultimately intended to be the
building block of canary.io.
- introduce the concept of a manifest
- fetch Manifest from an external source
- breadboard to manage wiring things together
- librato reporter to deliver results to librato
