### PR TITLE
publisher: fix STDOUT reporting, add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,10 @@ $ go get github.com/canaryio/canary/cmd/canary
 
 ```sh
 $ canary http://www.canary.io
-2014/12/24 21:23:12 http://www.canary.io 200 129 true
-2014/12/24 21:23:13 http://www.canary.io 200 91 true
-2014/12/24 21:23:14 http://www.canary.io 200 89 true
-2014/12/24 21:23:15 http://www.canary.io 200 88 true
-2014/12/24 21:23:16 http://www.canary.io 200 94 true
+2014-12-28T14:44:32Z http://www.canary.io 200 96 true
+2014-12-28T14:44:33Z http://www.canary.io 200 92 true
+2014-12-28T14:44:34Z http://www.canary.io 200 89 true
+2014-12-28T14:44:35Z http://www.canary.io 200 124 true
 ^C
 ```
 

--- a/publisher.go
+++ b/publisher.go
@@ -2,7 +2,7 @@ package canary
 
 import (
 	"fmt"
-	"log"
+	"time"
 )
 
 // Publisher is the interface that adds the Publish method.
@@ -32,6 +32,6 @@ func (p StdoutPublisher) Publish(site Site, sample Sample, err error) error {
 		errMessage = fmt.Sprintf("'%s'", err)
 	}
 
-	log.Printf("%s %d %d %t %s", site.URL, sample.StatusCode, duration, isOK, errMessage)
+	fmt.Printf("%s %s %d %d %t %s\n", sample.T2.Format(time.RFC3339), site.URL, sample.StatusCode, duration, isOK, errMessage)
 	return nil
 }

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -1,0 +1,23 @@
+package canary
+
+import "time"
+
+func ExampleStdoutPublisher_Publish() {
+	site := Site{
+		URL: "http://www.canary.io",
+	}
+
+	t1, _ := time.Parse(time.RFC3339, "2014-12-28T00:00:00Z")
+	t2, _ := time.Parse(time.RFC3339, "2014-12-28T00:00:01Z")
+
+	sample := Sample{
+		T1:         t1,
+		T2:         t2,
+		StatusCode: 200,
+	}
+
+	p := StdoutPublisher{}
+	p.Publish(site, sample, nil)
+	// Output:
+	// 2014-12-28T00:00:01Z http://www.canary.io 200 1000 true
+}


### PR DESCRIPTION
I mistakenly thought that the `log` package reported to STDOUT, but it
reports to STDERR.  This moves us to `fmt`.

I also added a test for the `StdoutPublisher`.
