### PR TITLE
bump to v3

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package canary
 
 // the public version of canary
-const Version string = "v2"
+const Version string = "v3"


### PR DESCRIPTION
ref #6 

makes this v3 release official, outside of the GitHub Release.