### PR TITLE
Configure sampling interval via environment variables and per-url manifest targets

### DIFF
--- a/cmd/canary/README.md
+++ b/cmd/canary/README.md
@@ -13,6 +13,12 @@ $ go get github.com/canaryio/canary/cmd/canary
 
 ## Usage
 
+The first and only argument to canary is the url to check. The environment variable
+SAMPLE_INTERVAL defines the interval (in seconds) to check the url. When the variable is
+unset, the default of 1 second is used. 
+
+To run canary with the default sampling interval:
+
 ```sh
 $ canary http://www.canary.io
 2014-12-28T14:44:32Z http://www.canary.io 200 96 true
@@ -20,6 +26,17 @@ $ canary http://www.canary.io
 2014-12-28T14:44:34Z http://www.canary.io 200 89 true
 2014-12-28T14:44:35Z http://www.canary.io 200 124 true
 ^C
+```
+
+To run canary with a 5 second sampling interval:
+
+```sh
+$ SAMPLE_INTERVAL=5 canary http://www.canary.io
+2015-02-18T00:23:45-05:00 http://www.canary.io 200 78.111876 true 
+2015-02-18T00:23:50-05:00 http://www.canary.io 200 72.897346 true 
+2015-02-18T00:23:55-05:00 http://www.canary.io 200 60.863369 true 
+2015-02-18T00:24:00-05:00 http://www.canary.io 200 69.095778 true 
+^C^C
 ```
 
 ## Output

--- a/cmd/canaryd/README.md
+++ b/cmd/canaryd/README.md
@@ -15,10 +15,13 @@ $ go get github.com/canaryio/canary/cmd/canaryd
 
 * `MANIFEST_URL` - ref to a JSON document describing what needs to be monitored
 * `PUBLISHERS` - an explicit list of pubilshers to enable, defaulting to `stdout`
+* `DEFAULT_SAMPLE_INTERVAL` - interval rate (in seconds) for targets without a defined interval value, defaults to 1 second.
 
 ## Manifest
 
 A manifest is a simple JSON document describing the sites to be monitored.  You must create such a document and host it somewhere so that it is accessible to `canaryd`.
+
+Within the manifest, targets are defined as a json object with the required keys 'url' and 'name'. 'interval' is optional, and will define the interval rate in seconds to check the specific url, overriding the default interval settings in canaryd
 
 An example manifest:
 
@@ -39,7 +42,8 @@ An example manifest:
     },
     {
       "url": "https://github.com",
-      "name": "github"
+      "name": "github",
+      "interval": 60
     }
   ]
 }

--- a/cmd/canaryd/main.go
+++ b/cmd/canaryd/main.go
@@ -34,6 +34,7 @@ func getConfig() (c config, err error) {
 	c.PublisherList = strings.Split(list, ",")
 
 	interval := os.Getenv("DEFAULT_SAMPLE_INTERVAL")
+	// if the variable is unset, an empty string will be returned
 	if interval == "" {
 		interval = "1"
 	}
@@ -82,6 +83,8 @@ func main() {
 	for _, target := range manifest.Targets {
 		// Determine whether to use target.Interval or conf.DefaultSampleInterval
 		var interval int;
+		// Targets that lack an interval value in JSON will have their value set to zero. in this case,
+		// use the DefaultSampleInterval
 		if target.Interval == 0 {
 			interval = conf.DefaultSampleInterval
 		} else {

--- a/cmd/canaryd/main.go
+++ b/cmd/canaryd/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"strconv"
 
 	"github.com/canaryio/canary"
 	"github.com/canaryio/canary/pkg/libratopublisher"
@@ -15,6 +16,7 @@ import (
 
 type config struct {
 	ManifestURL   string
+	DefaultSampleInterval int
 	PublisherList []string
 }
 
@@ -30,6 +32,15 @@ func getConfig() (c config, err error) {
 		list = "stdout"
 	}
 	c.PublisherList = strings.Split(list, ",")
+
+	interval := os.Getenv("DEFAULT_SAMPLE_INTERVAL")
+	if interval == "" {
+		interval = "1"
+	}
+	c.DefaultSampleInterval, err = strconv.Atoi(interval)
+	if err != nil {
+		err = fmt.Errorf("DEFAULT_SAMPLE_INTERVAL is not a valid integer")
+	}
 
 	return
 }
@@ -69,12 +80,19 @@ func main() {
 
 	// spinup a sensor for each target
 	for _, target := range manifest.Targets {
+		// Determine whether to use target.Interval or conf.DefaultSampleInterval
+		var interval int;
+		if target.Interval == 0 {
+			interval = conf.DefaultSampleInterval
+		} else {
+			interval = target.Interval
+		}
 		sensor := sensor.Sensor{
 			Target:  target,
 			C:       c,
 			Sampler: sampler.New(),
 		}
-		go sensor.Start()
+		go sensor.Start(interval)
 	}
 
 	// publish each incoming measurement

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestGetManifest(t *testing.T) {
+func TestGetManifestWithoutInterval(t *testing.T) {
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		data := `{
 			"targets": [
@@ -40,5 +40,50 @@ func TestGetManifest(t *testing.T) {
 
 	if target.URL != "http://www.canary.io" {
 		t.Fatal("expected URL to be equal to 'http://www.canary.io', got %s", target.URL)
+	}
+
+	if target.Interval != 0 {
+		t.Fatal("expected Interval to be equal to zero when undefined in the manifest json, got %d", target.Interval)
+	}
+}
+
+func TestGetManifestWithInterval(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		data := `{
+			"targets": [
+				{
+					"url": "http://www.canary.io",
+					"name": "canary",
+					"interval": 2
+				},
+				{
+					"url": "http://www.github.com",
+					"name": "github",
+					"interval": 4
+				}
+			]
+		}`
+
+		fmt.Fprintf(w, data)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(handler))
+	defer ts.Close()
+
+	m, err := GetManifest(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first_target := m.Targets[0]
+
+	if first_target.Interval != 2 {
+		t.Fatal("expected Interval on the first target to be equal to the manifest json definition of 2, got %d", first_target.Interval)
+	}
+
+	second_target := m.Targets[1]
+
+	if second_target.Interval != 4 {
+		t.Fatal("expected Interval on the second target to be equal to the manifest json definition of 4, got %d", second_target.Interval)
 	}
 }

--- a/pkg/sampler/sampler.go
+++ b/pkg/sampler/sampler.go
@@ -11,6 +11,7 @@ import (
 type Target struct {
 	URL  string
 	Name string
+	Interval int
 }
 
 type Sample struct {

--- a/pkg/sensor/sensor.go
+++ b/pkg/sensor/sensor.go
@@ -33,11 +33,11 @@ func (s *Sensor) measure() Measurement {
 }
 
 // Start is meant to be called within a goroutine, and fires up the main event loop.
-func (s *Sensor) Start() {
+func (s *Sensor) Start(interval int) {
 	if s.stopChan == nil {
 		s.stopChan = make(chan int)
 	}
-	t := time.NewTicker(time.Second)
+	t := time.NewTicker((time.Second * time.Duration(interval)))
 
 	for {
 		select {


### PR DESCRIPTION
I discovered canaryd a few days ago and have been evaluating it for a project I am helping on. I have been very happy with the project and want to contribute to it on some missing features. I found it lacking that the check interval is hard coded into the source, and cannot be defined per-target for canaryd. 

This patch adds support for tuning the sample interval rates in both canary and canaryd, as well as allowing targets to have independent interval rates as defined in the Manifest JSON.

I am relatively new to Golang, so let me know if I have gaping issues, or the changes in here do not follow the style for canary. If this looks good, I will have other PRs for canary as there are some other things I would like to extend.

Thanks

