### PR TITLE
Trigger a measure when Sensor starts, then wait for NewTicker intervals

### DIFF
--- a/pkg/sensor/sensor.go
+++ b/pkg/sensor/sensor.go
@@ -39,6 +39,9 @@ func (s *Sensor) Start(interval int) {
 	}
 	t := time.NewTicker((time.Second * time.Duration(interval)))
 
+	// Measure, then wait for ticker interval
+	s.C <- s.measure()
+
 	for {
 		select {
 		case <-s.stopChan:


### PR DESCRIPTION
After #22, the sample interval is now dynamic. However, this means that with a high interval, no measurements are made until the Sensor ticker fires after the defined interval. 

This PR causes sensors to measure when Start() is called, which will enable canary to start generating results earlier while maintaining the interval.