### PR TITLE
Add RAMPUP_SENSORS=yes ENV variable to evenly start each target sensor with a delay

### DIFF
--- a/cmd/canary/main.go
+++ b/cmd/canary/main.go
@@ -25,7 +25,7 @@ func (cmd command) Run() {
 		C:       make(chan sensor.Measurement),
 		Sampler: cmd.sampler,
 	}
-	go sensor.Start(cmd.interval)
+	go sensor.Start(cmd.interval, 0.0) // Start delay of zero.
 
 	for m := range sensor.C {
 		cmd.publisher.Publish(m)

--- a/cmd/canaryd/README.md
+++ b/cmd/canaryd/README.md
@@ -16,6 +16,7 @@ $ go get github.com/canaryio/canary/cmd/canaryd
 * `MANIFEST_URL` - ref to a JSON document describing what needs to be monitored
 * `PUBLISHERS` - an explicit list of pubilshers to enable, defaulting to `stdout`
 * `DEFAULT_SAMPLE_INTERVAL` - interval rate (in seconds) for targets without a defined interval value, defaults to 1 second.
+* `RAMPUP_SENSORS` - When set to 'yes', configure a delayed start for each target sensors, with the delay based on an even division of DEFAULT_SAMPLE_INTERVAL by the target index. This assists with performance for large numbers of targets. This will cause all targets to be measured within one full DEFAULT_SAMPLE_INTERVAL when starting.
 
 ## Manifest
 
@@ -47,6 +48,24 @@ An example manifest:
     }
   ]
 }
+```
+
+## Rampup sensors option
+
+This ENV option allows each target to be started on an even division of the DEFAULT_SAMPLE_INTERVAL value. Executing with RAMPUP_SENSORS=yes on
+a 4 second DEFAULT_SAMPLE_INTERVAL:
+
+```sh
+$ MANIFEST_URL=http://www.canary.io/manifest.json DEFAULT_SAMPLE_INTERVAL=4 RAMPUP_SENSORS=yes ./canaryd
+2015-02-21T16:58:47-05:00 http://www.simple.com/ 301 71.189670 true
+2015-02-21T16:58:48-05:00 http://www.canary.io 200 2221.243963 true
+2015-02-21T16:58:49-05:00 http://github.com 301 130.786490 true
+2015-02-21T16:58:50-05:00 http://www.canary.io 200 164.862335 true
+2015-02-21T16:58:50-05:00 http://www.heroku.com 301 2248.900172 true
+2015-02-21T16:58:51-05:00 http://www.simple.com/ 301 43.400060 true
+2015-02-21T16:58:52-05:00 http://www.heroku.com 301 135.366210 true
+2015-02-21T16:58:53-05:00 http://github.com 301 67.303349 true
+^C
 ```
 
 ## Publishers

--- a/manifest.go
+++ b/manifest.go
@@ -11,6 +11,17 @@ import (
 // Manifest represents configuration data.
 type Manifest struct {
 	Targets []sampler.Target
+	StartDelays []float64
+}
+
+// GenerateRampupDelays generates an even distribution of sensor start delays
+// based on the passed number of interval seconds and the number of targets.
+func (m *Manifest) GenerateRampupDelays(intervalSeconds int) {
+	var intervalMilliseconds = float64(intervalSeconds*1000)
+	var chunkSize = float64(intervalMilliseconds/float64(len(m.Targets)))
+	for i := 0.0; i < intervalMilliseconds; i = i + chunkSize {
+		m.StartDelays[int((i/chunkSize))] = i
+	}
 }
 
 // GetManifest retreives a manifest from a given URL.
@@ -29,6 +40,12 @@ func GetManifest(url string) (manifest Manifest, err error) {
 	err = json.Unmarshal(body, &manifest)
 	if err != nil {
 		return
+	}
+
+	// Initialize manifest.StartDelays to zeros
+	manifest.StartDelays = make([]float64, len(manifest.Targets))
+	for i := 0; i < len(manifest.Targets); i++ {
+		manifest.StartDelays[i] = 0.0
 	}
 
 	return

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -87,3 +87,70 @@ func TestGetManifestWithInterval(t *testing.T) {
 		t.Fatal("expected Interval on the second target to be equal to the manifest json definition of 4, got %d", second_target.Interval)
 	}
 }
+
+func TestGetManifestRampup(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		data := `{
+			"targets": [
+				{
+					"url": "http://www.canary.io",
+					"name": "canary"
+				},
+				{
+					"url": "http://www.github.com",
+					"name": "github"
+				},
+				{
+					"url": "http://www.google.com",
+					"name": "google"
+				},
+				{
+					"url": "http://www.youtube.com",
+					"name": "youtube"
+				}
+			]
+		}`
+
+		fmt.Fprintf(w, data)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(handler))
+	defer ts.Close()
+
+	m, err := GetManifest(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// m.StartDelays will the same length as m.Targets
+	if len(m.Targets) != len(m.StartDelays) {
+		t.Fatal("expected length of m.StartDelays (%d) to match length of m.Targets (%d)", len(m.Targets), len(m.StartDelays))
+	}
+
+	// without calling GenerateRampupDelays, StartDelays should all be zero.
+	for index, value := range m.StartDelays {
+		if value != 0.0 {
+			t.Fatal("Expected initial start delay to be 0.0, got %d for index %d", value, index)
+		}
+	}
+
+	// Calling GenerateRampupDelays will update m.StartDelays to an even distribution of
+	// millisecond delays for the passed Sampling interval (in seconds).
+	m.GenerateRampupDelays(10)
+
+	if m.StartDelays[0] != 0.0 {
+		t.Fatal("The first start delay should be 0.0 even after generation, got %d", m.StartDelays[0])
+	}
+
+	if m.StartDelays[1] != 2500.0 {
+		t.Fatal("The second start delay should be 2500.0 ms after generation, got %d", m.StartDelays[1])
+	}
+
+	if m.StartDelays[2] != 5000.0 {
+		t.Fatal("The second start delay should be 5000.0 ms after generation, got %d", m.StartDelays[2])
+	}
+
+	if m.StartDelays[3] != 7500.0 {
+		t.Fatal("The second start delay should be 7500.0 ms after generation, got %d", m.StartDelays[3])
+	}
+}

--- a/pkg/sensor/sensor.go
+++ b/pkg/sensor/sensor.go
@@ -33,10 +33,16 @@ func (s *Sensor) measure() Measurement {
 }
 
 // Start is meant to be called within a goroutine, and fires up the main event loop.
-func (s *Sensor) Start(interval int) {
+// interval is number of seconds. delay is number of ms.
+func (s *Sensor) Start(interval int, delay float64) {
 	if s.stopChan == nil {
 		s.stopChan = make(chan int)
 	}
+
+	// Delay for loop start offset.
+	time.Sleep((time.Millisecond * time.Duration(delay)))
+
+	// Start the ticker for this sensors interval
 	t := time.NewTicker((time.Second * time.Duration(interval)))
 
 	for {


### PR DESCRIPTION
Upon testing canaryd with a large target set (hundreds of targets) I noticed that canaryd starts each target Sensor at the same time, after the defined DEFAULT_SAMPLE_INTERVAL. When loading hundreds of urls this can impact performance due to the high concurrency of targets executing at the same time.

When loading a list of "top 1000 urls" on a 15 second DEFAULT_SAMPLE_INTERVAL, and running dstat, before this patch I see on an m3.large AWS instance:

```
----total-cpu-usage---- -dsk/total- -net/total- ---paging-- ---system--
usr sys idl wai hiq siq| read  writ| recv  send|  in   out | int   csw 
  0   0 100   0   0   0|   0     0 | 185B  482B|   0     0 | 154   211 
  0   0 100   0   0   0|   0     0 |4062B 6222B|   0     0 |  95   104 
  1   0 100   0   0   0|   0     0 |2034B 2636B|   0     0 | 133   146 
  0   0  99   0   0   0|   0    24k|3941B 6113B|   0     0 | 123   167 
  0   0 100   0   0   0|   0    36k|  52B  354B|   0     0 |  46    63 
  0   0 100   0   0   0|   0     0 |3166B 5177B|   0     0 |  74    92 
  0   0 100   0   0   0|   0     0 |  52B  354B|   0     0 |  31    52 
  2   4  95   0   0   1|   0     0 | 114k   81k|   0     0 |3793  2831 
 18  14  62   0   0   6|   0    60k|3151k  643k|   0     0 |  40k   32k
  3   0  97   0   0   1|   0  4096B|1814k   66k|   0     0 |3238  2815 
 15   2  83   0   0   0|   0     0 | 665k   21k|   0     0 |1328  1235 
  0   0 100   0   0   0|   0     0 |  68k 4980B|   0     0 | 235   236 
  0   1 100   0   0   0|   0     0 |  19k 6142B|   0     0 | 109   140 
  0   0 100   0   0   0|   0    80k| 494B  850B|   0     0 |  73    97 
  0   0 100   0   0   0|   0     0 |  18k 6527B|   0     0 | 132   136 
  0   0 100   0   0   0|   0     0 |  52B  354B|   0     0 | 192   209 
  0   0 100   0   0   0|   0     0 |3166B 5177B|   0     0 |  74    89 
  0   0 100   0   0   0|   0     0 | 353B  700B|   0     0 |  49    87 
  1   0 100   0   0   0|   0    44k|3871B 5995B|   0     0 | 131   150 
  1   0  99   0   0   0|   0  8192B| 324B 1910B|   0     0 |  41    54 
  0   0 100   0   0   0|   0     0 |3166B 5177B|   0     0 |  72    84 
  0   0 100   0   0   0|   0     0 |  92B  354B|   0     0 |  26    42 
  2   3  95   0   0   1|   0     0 | 117k   83k|   0     0 |4026  2912 
 19  16  61   0   0   4|   0  8192B|3164k  636k|   0     0 |  40k   31k
  3   1  96   0   0   1|   0     0 |1840k   69k|   0     0 |3378  2655 
  0   0 100   0   0   0|   0     0 | 597k   19k|   0     0 |1169  1120 
  0   0 100   0   0   0|   0     0 |  89k   10k|   0     0 | 330   317 
  0   0 100   0   0   0|   0     0 |  12k 1123B|   0     0 |  71   105 
----total-cpu-usage---- -dsk/total- -net/total- ---paging-- ---system--
usr sys idl wai hiq siq| read  writ| recv  send|  in   out | int   csw 
  1   0 100   0   0   0|   0    92k|5720B 6716B|   0     0 | 153   215 
  0   1  99   0   0   0|   0     0 | 196B 2383B|   0     0 |  35    45 
  0   0 100   0   0   0|   0     0 |3166B 5177B|   0     0 | 242   228 
  0   0 100   0   0   0|   0     0 |  92B  354B|   0     0 |  23    35 
  0   0 100   0   0   0|   0     0 |3677B 5861B|   0     0 |  91   108 
  0   0 100   0   0   1|   0    32k|1640B 1087B|   0     0 |  77   102 
  0   0 100   0   0   0|   0     0 |3166B 5177B|   0     0 |  77    99 
  0   0 100   0   0   0|   0     0 |  92B  354B|   0     0 |  24    40 
  0   0 100   0   0   0|   0     0 |3206B 5177B|   0     0 |  81    86 
  3   2  96   0   0   0|   0     0 |  82k   56k|   0     0 |4497  3771 
 23  13  61   0   0   4|   0  8192B|2873k  613k|   0     0 |  36k   28k
  3   1  96   0   0   0|   0     0 |1669k   57k|   0     0 |2954  2375 
  1   0  99   0   0   0|   0     0 | 399k   17k|   0     0 | 819   781
```

We can see CPU idle drop ~40% due to all urls being checked at the same time. I've also noticed that the reported request_time is impacted by this as well. With this patch applied, performance is smoothed out considerably: 

```
  2   1  97   0   0   1|   0    24k| 682k   64k|   0     0 |3175  2661 
  1   2  97   0   0   1|   0     0 | 295k   53k|   0     0 |2672  2124 
  1   2  97   0   0   0|   0     0 | 180k   51k|   0     0 |2168  2023 
  2   2  96   0   0   0|   0     0 | 198k   50k|   0     0 |2367  2167 
  2   2  95   0   0   1|   0    24k| 518k   63k|   0     0 |2884  2405 
  1   1  98   0   0   1|   0    36k| 260k   49k|   0     0 |2488  1911 
  1   2  97   0   0   0|   0     0 | 168k   54k|   0     0 |2414  1828 
  1   1  97   0   0   1|   0     0 | 463k   55k|   0     0 |2874  2187 
  3   0  97   0   0   0|   0     0 | 499k   62k|   0     0 |2902  2282 
  2   2  95   0   0   1|   0    20k| 314k   56k|   0     0 |2668  1949 
  2   1  97   0   0   1|   0    24k| 213k   52k|   0     0 |2550  2144 
  2   0  97   0   0   1|   0     0 | 330k   54k|   0     0 |2474  1979 
  2   2  96   0   0   0|   0     0 | 319k   53k|   0     0 |2554  2189 
  1   1  98   0   0   1|   0     0 | 404k   63k|   0     0 |3064  2495 
  2   1  97   0   0   1|   0    36k| 889k   70k|   0     0 |3721  3508 
  2   1  97   1   0   1|   0    24k| 735k   70k|   0     0 |3311  2980 
  2   2  96   0   0   0|   0     0 | 313k   57k|   0     0 |2650  2117 
  2   2  97   0   0   0|   0     0 | 187k   51k|   0     0 |2258  2311 
  2   2  95   0   0   1|   0     0 | 197k   50k|   0     0 |2436  2067 
  4   1  95   0   0   0|   0    24k| 457k   62k|   0     0 |2837  2325 
  1   1  97   0   0   1|   0    28k| 305k   52k|   0     0 |2557  2090 
  1   1  98   0   0   1|   0     0 | 189k   52k|   0     0 |2440  1928 
  1   0  98   0   0   1|   0     0 | 387k   54k|   0     0 |2761  2163 
  2   1  96   0   0   1|   0     0 | 597k   68k|   0     0 |3219  2538 
  3   1  95   0   0   0|   0    20k| 315k   53k|   0     0 |2603  2221 
  1   1  96   0   0   1|   0    24k| 255k   58k|   0     0 |2659  1993 
----total-cpu-usage---- -dsk/total- -net/total- ---paging-- ---system--
usr sys idl wai hiq siq| read  writ| recv  send|  in   out | int   csw 
  2   0  98   0   0   0|   0     0 | 341k   51k|   0     0 |2367  2130 
 17   4  79   0   0   0|   0     0 | 287k   60k|   0     0 |2547  2015 
  1   1  99   0   0   0|   0     0 | 617k   65k|   0     0 |3322  2846 
  2   1  98   0   0   0|   0    52k| 703k   64k|   0     0 |3036  2619 
  1   1  97   0   0   1|   0    40k| 647k   62k|   0     0 |3106  2721 
  1   1  98   0   0   1|   0     0 | 348k   58k|   0     0 |2681  2211 
  1   2  96   0   0   0|   0     0 | 236k   48k|   0     0 |2263  2095 
  1   2  96   0   0   0|   0     0 | 200k   55k|   0     0 |2394  2208 
  2   2  95   0   0   0|   0    44k| 502k   60k|   0     0 |2972  2370 
  2   1  97   0   0   1|   0    36k| 304k   56k|   0     0 |2670  2321 
  3   1  96   0   0   0|   0     0 | 214k   51k|   0     0 |2295  2135 
```

The result is that the performance is evened out and we dont see as many spikes in local resources when all target sensors fire measurements at the same time. The cost here is that some targets can take the full DEFAULT_SAMPLE_INTERVAL to measure.

Let me know if you would want to have RAMPUP_SENSORS  accept options for 'even' vs. 'random'. Currently this only does the delays evenly, but it wouldn't be difficult to have the start delay be randomized as opposed to evenly determined off of DEFAULT_SAMPLE_INTERVAL. 