### PR TITLE
Create Canary struct with common execution logic, and add manifest reloading on SIGHUP

### DIFF
--- a/canary.go
+++ b/canary.go
@@ -1,0 +1,141 @@
+package canary
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/canaryio/canary/pkg/libratopublisher"
+	"github.com/canaryio/canary/pkg/manifest"
+	"github.com/canaryio/canary/pkg/sampler"
+	"github.com/canaryio/canary/pkg/sensor"
+	"github.com/canaryio/canary/pkg/stdoutpublisher"
+)
+
+type Canary struct {
+	Config     Config
+	Manifest   manifest.Manifest
+	Publishers []Publisher
+	Sensors    []sensor.Sensor
+	OutputChan chan sensor.Measurement
+	ReloadChan chan bool
+}
+
+// New returns a pointer to a new Publsher.
+func New() *Canary {
+	return &Canary{OutputChan: make(chan sensor.Measurement)}
+}
+
+func (c *Canary) publishMeasurements() {
+	// publish each incoming measurement
+	for m := range c.OutputChan {
+		for _, p := range c.Publishers {
+			p.Publish(m)
+		}
+	}
+}
+
+func (c *Canary) SignalHandler() {
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGINT)
+	signal.Notify(signalChan, syscall.SIGHUP)
+	for s := range signalChan {
+		switch s {
+		case syscall.SIGINT:
+			for _, sensor := range c.Sensors {
+				sensor.Stop()
+			}
+			os.Exit(0)
+		case syscall.SIGHUP:
+			// Split reload logic into reloader() as to allow other things to trigger a manifest reload
+			c.ReloadChan <- true
+		}
+	}
+}
+
+func (c *Canary) reloader() {
+	if c.ReloadChan == nil {
+		c.ReloadChan = make(chan bool)
+	}
+
+	for r := range c.ReloadChan {
+		if r {
+			// stop all running sensors
+			for _, sensor := range c.Sensors {
+				sensor.Stop()
+			}
+			for _, sensor := range c.Sensors {
+				<-sensor.IsStopped
+			}
+
+			// get an updated manifest.
+			manifest, err := manifest.GetManifest(c.Config.ManifestURL)
+			if err != nil {
+				log.Fatal(err)
+			}
+			c.Manifest = manifest
+			if c.Config.RampupSensors {
+				c.Manifest.GenerateRampupDelays(c.Config.DefaultSampleInterval)
+			}
+			// Start new sensors:
+			c.startSensors()
+		}
+	}
+}
+
+func (c *Canary) createPublishers() {
+	for _, publisher := range c.Config.PublisherList {
+		switch publisher {
+		case "stdout":
+			p := stdoutpublisher.New()
+			c.Publishers = append(c.Publishers, p)
+		case "librato":
+			p, err := libratopublisher.NewFromEnv()
+			if err != nil {
+				log.Fatal(err)
+			}
+			c.Publishers = append(c.Publishers, p)
+		default:
+			log.Printf("Unknown publisher: %s", publisher)
+		}
+	}
+}
+
+func (c *Canary) startSensors() {
+	c.Sensors = []sensor.Sensor{} // reset the slice
+
+	// spinup a sensor for each target
+	for index, target := range c.Manifest.Targets {
+		// Determine whether to use target.Interval or conf.DefaultSampleInterval
+		var interval int
+		// Targets that lack an interval value in JSON will have their value set to zero. in this case,
+		// use the DefaultSampleInterval
+		if target.Interval == 0 {
+			interval = c.Config.DefaultSampleInterval
+		} else {
+			interval = target.Interval
+		}
+		sensor := sensor.Sensor{
+			Target:    target,
+			C:         c.OutputChan,
+			Sampler:   sampler.New(),
+			StopChan:  make(chan int, 1),
+			IsStopped: make(chan bool),
+		}
+		c.Sensors = append(c.Sensors, sensor)
+
+		go sensor.Start(interval, c.Manifest.StartDelays[index])
+	}
+}
+
+func (c *Canary) Run() {
+	// spinup publishers
+	c.createPublishers()
+	// create and start sensors
+	c.startSensors()
+	// start a go routine for watching config reloads
+	go c.reloader()
+	// start a go routine for measurement publishing.
+	go c.publishMeasurements()
+}

--- a/config.go
+++ b/config.go
@@ -1,0 +1,8 @@
+package canary
+
+type Config struct {
+	ManifestURL           string
+	DefaultSampleInterval int
+	RampupSensors         bool
+	PublisherList         []string
+}

--- a/pkg/canaryversion/version.go
+++ b/pkg/canaryversion/version.go
@@ -1,4 +1,4 @@
-package canary
+package canaryversion
 
 // the public version of canary
 const Version string = "v3"

--- a/pkg/libratoaggregator/aggregator.go
+++ b/pkg/libratoaggregator/aggregator.go
@@ -4,11 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/canaryio/canary/pkg/canaryversion"
 	"log"
 	"net/http"
 	"time"
-
-	"github.com/canaryio/canary"
 )
 
 type gauge struct {
@@ -118,7 +117,7 @@ func (a *Aggregator) flush() error {
 	}
 
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("User-Agent", "canary/"+canary.Version)
+	req.Header.Add("User-Agent", "canary/"+canaryversion.Version)
 
 	req.SetBasicAuth(a.User, a.Token)
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -10,19 +10,19 @@ import (
 
 // Manifest represents configuration data.
 type Manifest struct {
-	Targets []sampler.Target
+	Targets     []sampler.Target
 	StartDelays []float64
 }
 
 // GenerateRampupDelays generates an even distribution of sensor start delays
 // based on the passed number of interval seconds and the number of targets.
 func (m *Manifest) GenerateRampupDelays(intervalSeconds int) {
-	var intervalMilliseconds = float64(intervalSeconds*1000)
+	var intervalMilliseconds = float64(intervalSeconds * 1000)
 
-	var chunkSize = float64(intervalMilliseconds/float64(len(m.Targets)))
+	var chunkSize = float64(intervalMilliseconds / float64(len(m.Targets)))
 
 	for i := 0.0; i < intervalMilliseconds; i = i + chunkSize {
-		m.StartDelays[int((i/chunkSize))] = i
+		m.StartDelays[int((i / chunkSize))] = i
 	}
 }
 

--- a/pkg/sampler/sampler.go
+++ b/pkg/sampler/sampler.go
@@ -9,8 +9,8 @@ import (
 )
 
 type Target struct {
-	URL  string
-	Name string
+	URL      string
+	Name     string
 	Interval int
 }
 


### PR DESCRIPTION
This is a decent sized refactor, but was needed not only to consolidate common code but help enable reloading of the manifest on a SIGHUP signal.

note: this will probably not merge cleanly with #25, although it might. It includes that PR as well.

Most of the logic from canaryd's main() method has been moved into the Canary.Run() method, with the Canary type holding more info about how canary should run than it has in the past. In doing this, i was able to relatively easily add a signal handler for SIGINT (to exit) and for SIGHUP to initiate a config reload.

Config reloading is done via the Canary.reloader() method, which listens on the ReloadChan. This means we can add in later a polling for the Manifest, and if the manifest changes automatically trigger a reload via pushing to the ReloadChan.

This also should make the goal of the 'one-cmd' branch a bit easier since the core execution logic is consolidated in the Canary type, similar to how the 'canary' binary had the 'command' type. 