### PR TITLE
Track a given states count within Sensor, and add it to stdoutpublisher

### DIFF
--- a/canary.go
+++ b/canary.go
@@ -122,6 +122,7 @@ func (c *Canary) startSensors() {
 			Sampler:   sampler.New(),
 			StopChan:  make(chan int, 1),
 			IsStopped: make(chan bool),
+			IsOK:      false,
 		}
 		c.Sensors = append(c.Sensors, sensor)
 

--- a/pkg/sensor/sensor.go
+++ b/pkg/sensor/sensor.go
@@ -8,29 +8,46 @@ import (
 
 // Measurement reprents an aggregate of Target, Sample and error.
 type Measurement struct {
-	Target sampler.Target
-	Sample sampler.Sample
-	Error  error
+	Target     sampler.Target
+	Sample     sampler.Sample
+	IsOK       bool
+	StateCount int
+	Error      error
 }
 
 // Sensor is capable of repeatedly measuring a given Target
 // with a specific Sampler, and returns those results over channel C.
 type Sensor struct {
-	Target    sampler.Target
-	C         chan Measurement
-	Sampler   sampler.Sampler
-	StopChan  chan int
-	IsStopped chan bool
+	Target       sampler.Target
+	C            chan Measurement
+	Sampler      sampler.Sampler
+	StateCounter int
+	StopChan     chan int
+	IsStopped    chan bool
+	IsOK         bool
 }
 
 // take a sample against a target.
 func (s *Sensor) measure() Measurement {
 	sample, err := s.Sampler.Sample(s.Target)
-	return Measurement{
+	m := Measurement{
 		Target: s.Target,
 		Sample: sample,
 		Error:  err,
 	}
+
+	// Record the pass/fail for this measurement
+	m.IsOK = (m.Error == nil)
+
+	// Update the Sensors value for IsOK and counter for said state.
+	if s.IsOK != m.IsOK {
+		s.IsOK = m.IsOK
+		s.StateCounter = 0
+	}
+	s.StateCounter++
+	m.StateCount = s.StateCounter
+
+	return m
 }
 
 // Start is meant to be called within a goroutine, and fires up the main event loop.

--- a/pkg/stdoutpublisher/publisher.go
+++ b/pkg/stdoutpublisher/publisher.go
@@ -18,25 +18,19 @@ func New() *Publisher {
 
 // Publish takes a canary.Measurement and emits data to STDOUT.
 func (p *Publisher) Publish(m sensor.Measurement) (err error) {
-	duration := m.Sample.T2.Sub(m.Sample.T1).Seconds() * 1000
-
-	isOK := true
-	if m.Error != nil {
-		isOK = false
-	}
-
 	errMessage := ``
 	if m.Error != nil {
 		errMessage = fmt.Sprintf("'%s'", m.Error)
 	}
 
 	fmt.Printf(
-		"%s %s %d %f %t %s\n",
+		"%s %s %d %f %t %d %s\n",
 		m.Sample.T2.Format(time.RFC3339),
 		m.Target.URL,
 		m.Sample.StatusCode,
-		duration,
-		isOK,
+		m.Sample.Latency(),
+		m.IsOK,
+		m.StateCount,
 		errMessage,
 	)
 	return

--- a/pkg/stdoutpublisher/publisher_test.go
+++ b/pkg/stdoutpublisher/publisher_test.go
@@ -23,9 +23,11 @@ func ExamplePublisher_Publish() {
 
 	p := New()
 	p.Publish(sensor.Measurement{
-		Target: target,
-		Sample: sample,
+		Target:     target,
+		Sample:     sample,
+		IsOK:       true,
+		StateCount: 2,
 	})
 	// Output:
-	// 2014-12-28T00:00:01Z http://www.canary.io 200 1000.000000 true
+	// 2014-12-28T00:00:01Z http://www.canary.io 200 1000.000000 true 2
 }


### PR DESCRIPTION
Now that #26 is committed, I can put this patch up.

This adds IsOK logic to Sensor (instead of the publisher), and tracks the number of concurrent checks in the current state. This will allow any consumers of publisher information to know if a url is 'flapping', at least based on concurrent passes/fails. The main thing this implementation lacks is the ability to specify whether a url failed 3/5 of the last checks (if not concurrent), but consumers of published information can do that correlation. 

Ideally the manifest would define the pass/fail conditions.