### PR TITLE
Move Publisher creation into program entrypoints

### DIFF
--- a/canary.go
+++ b/canary.go
@@ -6,11 +6,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/canaryio/canary/pkg/libratopublisher"
 	"github.com/canaryio/canary/pkg/manifest"
 	"github.com/canaryio/canary/pkg/sampler"
 	"github.com/canaryio/canary/pkg/sensor"
-	"github.com/canaryio/canary/pkg/stdoutpublisher"
 )
 
 type Canary struct {
@@ -23,8 +21,11 @@ type Canary struct {
 }
 
 // New returns a pointer to a new Publsher.
-func New() *Canary {
-	return &Canary{OutputChan: make(chan sensor.Measurement)}
+func New(publishers []Publisher) *Canary {
+	return &Canary{
+		Publishers: publishers,
+		OutputChan: make(chan sensor.Measurement),
+	}
 }
 
 func (c *Canary) publishMeasurements() {
@@ -84,24 +85,6 @@ func (c *Canary) reloader() {
 	}
 }
 
-func (c *Canary) createPublishers() {
-	for _, publisher := range c.Config.PublisherList {
-		switch publisher {
-		case "stdout":
-			p := stdoutpublisher.New()
-			c.Publishers = append(c.Publishers, p)
-		case "librato":
-			p, err := libratopublisher.NewFromEnv()
-			if err != nil {
-				log.Fatal(err)
-			}
-			c.Publishers = append(c.Publishers, p)
-		default:
-			log.Printf("Unknown publisher: %s", publisher)
-		}
-	}
-}
-
 func (c *Canary) startSensors() {
 	c.Sensors = []sensor.Sensor{} // reset the slice
 
@@ -130,8 +113,6 @@ func (c *Canary) startSensors() {
 }
 
 func (c *Canary) Run() {
-	// spinup publishers
-	c.createPublishers()
 	// create and start sensors
 	c.startSensors()
 	// start a go routine for watching config reloads

--- a/cmd/canary/main.go
+++ b/cmd/canary/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/canaryio/canary"
 	"github.com/canaryio/canary/pkg/sampler"
 	"github.com/canaryio/canary/pkg/manifest"
+	"github.com/canaryio/canary/pkg/stdoutpublisher"
 )
 
 // usage prints a useful usage message.
@@ -36,12 +37,11 @@ func main() {
 		usage()
 	}
 
-	c := canary.New()
+	c := canary.New([]canary.Publisher{ stdoutpublisher.New() })
 	conf := canary.Config{}
 	manifest := manifest.Manifest{}
 
 	conf.DefaultSampleInterval = sample_interval
-	conf.PublisherList = []string{"stdout"}
 	manifest.StartDelays = []float64{0.0}
 	manifest.Targets = []sampler.Target{ sampler.Target{URL: args[0]} }
 

--- a/config.go
+++ b/config.go
@@ -4,5 +4,4 @@ type Config struct {
 	ManifestURL           string
 	DefaultSampleInterval int
 	RampupSensors         bool
-	PublisherList         []string
 }


### PR DESCRIPTION
This allows for embedding canary.Canary in other applications that may bring their own publisher.  Delegating publisher creation to canary.Canary demands that the canary library know about every possible publisher.  So this is sort of (*sigh*) "batteries included", but does not mandate that embedders use Canary brand batteries.