### PR TITLE
Refactor default sample interval for target

### DIFF
--- a/canary.go
+++ b/canary.go
@@ -71,7 +71,7 @@ func (c *Canary) reloader() {
 			}
 
 			// get an updated manifest.
-			manifest, err := manifest.GetManifest(c.Config.ManifestURL)
+			manifest, err := manifest.GetManifest(c.Config.ManifestURL, c.Config.DefaultSampleInterval)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -90,15 +90,6 @@ func (c *Canary) startSensors() {
 
 	// spinup a sensor for each target
 	for index, target := range c.Manifest.Targets {
-		// Determine whether to use target.Interval or conf.DefaultSampleInterval
-		var interval int
-		// Targets that lack an interval value in JSON will have their value set to zero. in this case,
-		// use the DefaultSampleInterval
-		if target.Interval == 0 {
-			interval = c.Config.DefaultSampleInterval
-		} else {
-			interval = target.Interval
-		}
 		sensor := sensor.Sensor{
 			Target:    target,
 			C:         c.OutputChan,
@@ -109,7 +100,7 @@ func (c *Canary) startSensors() {
 		}
 		c.Sensors = append(c.Sensors, sensor)
 
-		go sensor.Start(interval, c.Manifest.StartDelays[index])
+		go sensor.Start(c.Manifest.StartDelays[index])
 	}
 }
 

--- a/cmd/canary/main.go
+++ b/cmd/canary/main.go
@@ -41,9 +41,13 @@ func main() {
 	conf := canary.Config{}
 	manifest := manifest.Manifest{}
 
-	conf.DefaultSampleInterval = sample_interval
 	manifest.StartDelays = []float64{0.0}
-	manifest.Targets = []sampler.Target{ sampler.Target{URL: args[0]} }
+	manifest.Targets = []sampler.Target{
+		sampler.Target{
+			URL: args[0],
+			Interval: sample_interval,
+		},
+	}
 
 	c.Config = conf
 	c.Manifest = manifest

--- a/cmd/canaryd/main.go
+++ b/cmd/canaryd/main.go
@@ -73,7 +73,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	manifest, err := manifest.GetManifest(conf.ManifestURL)
+	manifest, err := manifest.GetManifest(conf.ManifestURL, conf.DefaultSampleInterval)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -29,7 +29,7 @@ func (m *Manifest) GenerateRampupDelays(intervalSeconds int) {
 }
 
 // GetManifest retreives a manifest from a given URL.
-func GetManifest(url string) (manifest Manifest, err error) {
+func GetManifest(url string, defaultInterval int) (manifest Manifest, err error) {
 	var stream io.ReadCloser
 	
 	if url[:7] == "file://" {
@@ -54,6 +54,15 @@ func GetManifest(url string) (manifest Manifest, err error) {
 	err = json.Unmarshal(body, &manifest)
 	if err != nil {
 		return
+	}
+
+	// Determine whether to use target.Interval or defaultInterval
+	// Targets that lack an interval value in JSON will have their value set to zero. in this case,
+	// use defaultInterval
+	for ind := range manifest.Targets {
+		if manifest.Targets[ind].Interval == 0 {
+			manifest.Targets[ind].Interval = defaultInterval
+		}
 	}
 
 	// Initialize manifest.StartDelays to zeros

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -24,7 +24,7 @@ func TestGetManifestWithoutInterval(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(handler))
 	defer ts.Close()
 
-	m, err := GetManifest(ts.URL)
+	m, err := GetManifest(ts.URL, 42)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,8 +42,8 @@ func TestGetManifestWithoutInterval(t *testing.T) {
 		t.Fatalf("expected URL to be equal to 'http://www.canary.io', got %s", target.URL)
 	}
 
-	if target.Interval != 0 {
-		t.Fatalf("expected Interval to be equal to zero when undefined in the manifest json, got %d", target.Interval)
+	if target.Interval != 42 {
+		t.Fatal("expected Interval to be equal to 42 when undefined in the manifest json, got %d", target.Interval)
 	}
 }
 
@@ -70,7 +70,7 @@ func TestGetManifestWithInterval(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(handler))
 	defer ts.Close()
 
-	m, err := GetManifest(ts.URL)
+	m, err := GetManifest(ts.URL, 42)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func TestGetManifestWithTags(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(handler))
 	defer ts.Close()
 
-	m, err := GetManifest(ts.URL)
+	m, err := GetManifest(ts.URL, 42)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestGetManifestWithAttributes(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(handler))
 	defer ts.Close()
 
-	m, err := GetManifest(ts.URL)
+	m, err := GetManifest(ts.URL, 42)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestGetManifestRampup(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(handler))
 	defer ts.Close()
 
-	m, err := GetManifest(ts.URL)
+	m, err := GetManifest(ts.URL, 42)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sensor/sensor.go
+++ b/pkg/sensor/sensor.go
@@ -52,12 +52,12 @@ func (s *Sensor) measure() Measurement {
 
 // Start is meant to be called within a goroutine, and fires up the main event loop.
 // interval is number of seconds. delay is number of ms.
-func (s *Sensor) Start(interval int, delay float64) {
+func (s *Sensor) Start(delay float64) {
 	// Delay for loop start offset.
 	time.Sleep((time.Millisecond * time.Duration(delay)))
 
 	// Start the ticker for this sensors interval
-	t := time.NewTicker((time.Second * time.Duration(interval)))
+	t := time.NewTicker((time.Second * time.Duration(s.Target.Interval)))
 
 	// Measure, then wait for ticker interval
 	s.C <- s.measure()


### PR DESCRIPTION
Now set when the manifest is loaded.  This allows a Publisher to know the actual sample interval for a given target.