### PR TITLE
dont replace err unless err is nil

### DIFF
--- a/cmd/canaryd/main.go
+++ b/cmd/canaryd/main.go
@@ -26,9 +26,12 @@ func getConfig() (c canary.Config, err error) {
 	if interval == "" {
 		interval = "1"
 	}
-	c.DefaultSampleInterval, err = strconv.Atoi(interval)
-	if err != nil {
-		err = fmt.Errorf("DEFAULT_SAMPLE_INTERVAL is not a valid integer")
+
+	if err == nil {
+		c.DefaultSampleInterval, err = strconv.Atoi(interval)
+		if err != nil {
+			err = fmt.Errorf("DEFAULT_SAMPLE_INTERVAL is not a valid integer")
+		}
 	}
 
 	// Set RampupSensors if RAMPUP_SENSORS is set to 'yes'


### PR DESCRIPTION
b67bccbb introduced this regression. This fixes the return for err as to not be overwritten if MANIFEST_URL is not defined. sorry.

```
~/go/src/github.com/canaryio/canary/cmd/canaryd$ git branch | grep \*
* master
~/go/src/github.com/canaryio/canary/cmd/canaryd$ go build && ./canaryd 
panic: runtime error: slice bounds out of range
```

vs

```
~/go/src/github.com/canaryio/canary/cmd/canaryd$ git checkout manifest_error_handling
Switched to branch 'manifest_error_handling'
~/go/src/github.com/canaryio/canary/cmd/canaryd$ go build && ./canaryd 
2015/03/19 20:31:06 MANIFEST_URL not defined in ENV
```