### PR TITLE
Refactor manifest reloading and allow automatic updates via polling

### DIFF
--- a/cmd/canary/README.md
+++ b/cmd/canary/README.md
@@ -13,9 +13,13 @@ $ go get github.com/canaryio/canary/cmd/canary
 
 ## Usage
 
-The first and only argument to canary is the url to check. The environment variable
-SAMPLE_INTERVAL defines the interval (in seconds) to check the url. When the variable is
-unset, the default of 1 second is used. 
+The first and only argument to canary is the url to check. `canary` suppots the following two
+environment variables:
+
+* `SAMPLE_INTERVAL` - defines the interval (in seconds) to check the url. When the variable is
+unset, the default of 1 second is used.
+* `MAX_TIMEOUT` - The timeout value for requests to the url, with the default value of 10
+seconds if not specified.
 
 To run canary with the default sampling interval:
 

--- a/cmd/canary/main.go
+++ b/cmd/canary/main.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 
 	"github.com/canaryio/canary"
-	"github.com/canaryio/canary/pkg/sampler"
 	"github.com/canaryio/canary/pkg/manifest"
+	"github.com/canaryio/canary/pkg/sampler"
 	"github.com/canaryio/canary/pkg/stdoutpublisher"
 )
 
@@ -32,19 +32,30 @@ func main() {
 		err = fmt.Errorf("SAMPLE_INTERVAL is not a valid integer")
 	}
 
+	timeout := 0
+	defaultTimeout := os.Getenv("DEFAULT_MAX_TIMEOUT")
+	if defaultTimeout == "" {
+		timeout = 10
+	} else {
+		timeout, err = strconv.Atoi(defaultTimeout)
+		if err != nil {
+			err = fmt.Errorf("DEFAULT_MAX_TIMOEUT is not a valid integer")
+		}
+	}
+
 	args := flag.Args()
 	if len(args) < 1 {
 		usage()
 	}
 
-	c := canary.New([]canary.Publisher{ stdoutpublisher.New() })
-	conf := canary.Config{}
+	c := canary.New([]canary.Publisher{stdoutpublisher.New()})
+	conf := canary.Config{MaxSampleTimeout: timeout}
 	manifest := manifest.Manifest{}
 
 	manifest.StartDelays = []float64{0.0}
 	manifest.Targets = []sampler.Target{
 		sampler.Target{
-			URL: args[0],
+			URL:      args[0],
 			Interval: sample_interval,
 		},
 	}

--- a/config.go
+++ b/config.go
@@ -1,7 +1,11 @@
 package canary
 
+import "time"
+
 type Config struct {
 	ManifestURL           string
 	DefaultSampleInterval int
 	RampupSensors         bool
+	ReloadInterval        time.Duration
+	MaxSampleTimeout      int
 }

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -116,8 +116,8 @@ func TestGetManifestWithTags(t *testing.T) {
 	}
 
 	first_target := m.Targets[0]
-	
-	if (len(first_target.Tags) != 0) {
+
+	if len(first_target.Tags) != 0 {
 		t.Fatalf("expected Tags on the first target to be empty, got %v", first_target.Tags)
 	}
 
@@ -167,7 +167,7 @@ func TestGetManifestWithAttributes(t *testing.T) {
 	}
 
 	first_target := m.Targets[0]
-	
+
 	if first_target.Attributes != nil {
 		t.Fatalf("expected Attributes on the first target to be empty, got %v", first_target.Attributes)
 	}
@@ -178,11 +178,11 @@ func TestGetManifestWithAttributes(t *testing.T) {
 		t.Fatalf("expected Attributes on the second target to be equal to the manifest json definition, got %v", second_target.Attributes)
 	} else {
 		foo := second_target.Attributes["foo"]
-		
+
 		if foo != "bar" {
 			t.Fatalf("expected 'foo' element of Attributes on the second target to be equal to the manifest json definition of 'bar', got %s", foo)
 		}
-		
+
 		baz := second_target.Attributes["baz"]
 		if baz != "bap" {
 			t.Fatalf("expected 'baz' element of Attributes on the second target to be equal to the manifest json definition of 'bap', got %s", baz)

--- a/pkg/sampler/sampler_test.go
+++ b/pkg/sampler/sampler_test.go
@@ -18,7 +18,7 @@ func TestSample(t *testing.T) {
 		URL: ts.URL,
 	}
 
-	sampler := New()
+	sampler := New(10)
 	sample, err := sampler.Sample(target)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sensor/sensor.go
+++ b/pkg/sensor/sensor.go
@@ -2,7 +2,8 @@ package sensor
 
 import (
 	"time"
-
+	// "fmt"
+	// "errors"
 	"github.com/canaryio/canary/pkg/sampler"
 )
 
@@ -18,13 +19,14 @@ type Measurement struct {
 // Sensor is capable of repeatedly measuring a given Target
 // with a specific Sampler, and returns those results over channel C.
 type Sensor struct {
-	Target       sampler.Target
-	C            chan Measurement
-	Sampler      sampler.Sampler
-	StateCounter int
-	StopChan     chan int
-	IsStopped    chan bool
-	IsOK         bool
+	Target         sampler.Target
+	C              chan Measurement
+	Sampler        sampler.Sampler
+	StateCounter   int
+	StopChan       chan int
+	IsStopped      bool
+	StopNotifyChan chan bool
+	IsOK           bool
 }
 
 // take a sample against a target.
@@ -66,7 +68,8 @@ func (s *Sensor) Start(delay float64) {
 		<-t.C
 		select {
 		case <-s.StopChan:
-			s.IsStopped <- true
+			s.IsStopped = true
+			s.StopNotifyChan <- true
 			return
 		default:
 			s.C <- s.measure()


### PR DESCRIPTION
This patch adds three main components:

- Implement adjustable connection timeout max via an environment variable.
- Refactor manifest reloading to only operate on the removed/new/changed targets vs stop old + start new.
- Add automatic manifest reloading via polling on an interval defined in an environment variable.

This also supersedes #33 which I have closed in favor of this. #33 can be reopened if there is a problem with this patch.

In the commit, I also ran a `go fmt` on all source files for cleanup. 