### PR TITLE
Add ability to capture response headers from server

### DIFF
--- a/pkg/sampler/sampler.go
+++ b/pkg/sampler/sampler.go
@@ -107,7 +107,11 @@ func (s Sampler) Sample(target Target) (sample Sample, err error) {
 	
 	sample.ResponseHeaders = make(map[string]string, len(target.CaptureHeaders))
 	for _, header := range target.CaptureHeaders {
-		sample.ResponseHeaders[header] = resp.Header.Get(header)
+		val := resp.Header.Get(header)
+		
+		if val != "" {
+			sample.ResponseHeaders[header] = val
+		}
 	}
 
 	if sample.StatusCode >= 400 {

--- a/pkg/sampler/sampler.go
+++ b/pkg/sampler/sampler.go
@@ -20,6 +20,7 @@ type Target struct {
 	Tags       []string
 	Attributes map[string]string
 	Hash       string
+	CaptureHeaders []string
 }
 
 func (t *Target) SetHash() {
@@ -30,9 +31,10 @@ func (t *Target) SetHash() {
 }
 
 type Sample struct {
-	StatusCode int
-	T1         time.Time
-	T2         time.Time
+	StatusCode      int
+	T1              time.Time
+	T2              time.Time
+	ResponseHeaders map[string]string
 }
 
 // Latency returns the amount of milliseconds between T1
@@ -101,6 +103,11 @@ func (s Sampler) Sample(target Target) (sample Sample, err error) {
 	_, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return
+	}
+	
+	sample.ResponseHeaders = make(map[string]string, len(target.CaptureHeaders))
+	for _, header := range target.CaptureHeaders {
+		sample.ResponseHeaders[header] = resp.Header.Get(header)
 	}
 
 	if sample.StatusCode >= 400 {

--- a/pkg/sampler/sampler_test.go
+++ b/pkg/sampler/sampler_test.go
@@ -60,3 +60,32 @@ func TestSampleWithHeaders(t *testing.T) {
 		t.Fatalf("Expected header %s to equal %s but got %s", headerName, headerVal, sample.ResponseHeaders[headerName])
 	}
 }
+
+func TestSampleWithMissingHeader(t *testing.T) {
+	headerName := "X-Request-Id"
+	
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "ok")
+	}
+	ts := httptest.NewServer(http.HandlerFunc(handler))
+	defer ts.Close()
+
+	target := Target{
+		URL: ts.URL,
+		CaptureHeaders: []string{ headerName },
+	}
+
+	sampler := New()
+	sample, err := sampler.Sample(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if sample.StatusCode != 200 {
+		t.Fatalf("Expected sampleStatus == 200, but got %d\n", sample.StatusCode)
+	}
+	
+	if val, ok := sample.ResponseHeaders[headerName]; ok {
+		t.Fatalf("Expected header %s with missing value to be empty but was '%+v'", headerName, val)
+	}
+}

--- a/pkg/sampler/sampler_test.go
+++ b/pkg/sampler/sampler_test.go
@@ -28,3 +28,35 @@ func TestSample(t *testing.T) {
 		t.Fatalf("Expected sampleStatus == 200, but got %d\n", sample.StatusCode)
 	}
 }
+
+func TestSampleWithHeaders(t *testing.T) {
+	headerName := "X-Request-Id"
+	headerVal  := "abcd-1234"
+	
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(headerName, headerVal)
+		
+		fmt.Fprintf(w, "ok")
+	}
+	ts := httptest.NewServer(http.HandlerFunc(handler))
+	defer ts.Close()
+
+	target := Target{
+		URL: ts.URL,
+		CaptureHeaders: []string{ headerName },
+	}
+
+	sampler := New(10)
+	sample, err := sampler.Sample(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if sample.StatusCode != 200 {
+		t.Fatalf("Expected sampleStatus == 200, but got %d\n", sample.StatusCode)
+	}
+	
+	if sample.ResponseHeaders[headerName] != headerVal {
+		t.Fatalf("Expected header %s to equal %s but got %s", headerName, headerVal, sample.ResponseHeaders[headerName])
+	}
+}

--- a/pkg/sampler/sampler_test.go
+++ b/pkg/sampler/sampler_test.go
@@ -61,6 +61,38 @@ func TestSampleWithHeaders(t *testing.T) {
 	}
 }
 
+func TestSampleWithCanonicalizedHeaderName(t *testing.T) {
+	headerName := "x-request-id"
+	headerVal  := "abcd-1234"
+	
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Request-Id", headerVal)
+		
+		fmt.Fprintf(w, "ok")
+	}
+	ts := httptest.NewServer(http.HandlerFunc(handler))
+	defer ts.Close()
+
+	target := Target{
+		URL: ts.URL,
+		CaptureHeaders: []string{ headerName },
+	}
+
+	sampler := New()
+	sample, err := sampler.Sample(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if sample.StatusCode != 200 {
+		t.Fatalf("Expected sampleStatus == 200, but got %d\n", sample.StatusCode)
+	}
+	
+	if sample.ResponseHeaders[headerName] != headerVal {
+		t.Fatalf("Expected header %s to equal %s but got %s", headerName, headerVal, sample.ResponseHeaders[headerName])
+	}
+}
+
 func TestSampleWithMissingHeader(t *testing.T) {
 	headerName := "X-Request-Id"
 	


### PR DESCRIPTION
This makes it possible to capture selected response headers from the server for use by publishers.  For my particular use case, I want to capture specific backend servers responsible for a bad response, and additionally capture a per-request identifier we generate on the backend.