### PR TITLE
Add support for target-specific request headers

### DIFF
--- a/pkg/sampler/sampler.go
+++ b/pkg/sampler/sampler.go
@@ -20,6 +20,7 @@ type Target struct {
 	Tags       []string
 	Attributes map[string]string
 	Hash       string
+	RequestHeaders map[string]string
 }
 
 func (t *Target) SetHash() {
@@ -87,6 +88,10 @@ func (s Sampler) Sample(target Target) (sample Sample, err error) {
 	}
 
 	req.Header.Add("User-Agent", s.UserAgent)
+	
+	for key, val := range target.RequestHeaders {
+		req.Header.Add(key, val)
+	}
 
 	sample.T1 = time.Now()
 	defer func() { sample.T2 = time.Now() }()

--- a/pkg/sampler/sampler_test.go
+++ b/pkg/sampler/sampler_test.go
@@ -28,3 +28,37 @@ func TestSample(t *testing.T) {
 		t.Fatalf("Expected sampleStatus == 200, but got %d\n", sample.StatusCode)
 	}
 }
+
+func TestSampleWithRequestHeaders(t *testing.T) {
+	var header http.Header
+	
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		header = r.Header
+		
+		fmt.Fprintf(w, "ok")
+	}
+	ts := httptest.NewServer(http.HandlerFunc(handler))
+	defer ts.Close()
+
+	target := Target{
+		URL: ts.URL,
+		RequestHeaders: map[string]string{
+			"X-Foo": "bar",
+		},
+	}
+
+	sampler := New(10)
+	sample, err := sampler.Sample(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if sample.StatusCode != 200 {
+		t.Fatalf("Expected sampleStatus == 200, but got %d\n", sample.StatusCode)
+	}
+	
+	h := header.Get("X-Foo")
+	if h != "bar" {
+		t.Fatalf("Expected request header X-Foo to be 'bar' but was '%s'", h)
+	}
+}


### PR DESCRIPTION
Could be used for authorization, or to invoke header-specific behavior on the server.