### PR TITLE
ENH: make ssl cert verification optional

### DIFF
--- a/pkg/sampler/sampler.go
+++ b/pkg/sampler/sampler.go
@@ -20,10 +20,11 @@ type Target struct {
 	Name     string
 	Interval int
 	// metadata
-	Tags           []string
-	Attributes     map[string]string
-	Hash           string
-	RequestHeaders map[string]string
+	Tags               []string
+	Attributes         map[string]string
+	Hash               string
+	RequestHeaders     map[string]string
+	InsecureSkipVerify bool
 }
 
 func (t *Target) SetHash() {
@@ -134,7 +135,9 @@ func dial(t Target) (net.Conn, error) {
 	case "http":
 		return net.Dial("tcp", host)
 	case "https":
-		return tls.Dial("tcp", host, &tls.Config{})
+		return tls.Dial("tcp", host, &tls.Config{
+			InsecureSkipVerify: t.InsecureSkipVerify,
+		})
 	default:
 		return nil, fmt.Errorf("unknown scheme '%s'", u.Scheme)
 	}


### PR DESCRIPTION
ref #46

Makes SSL cert verification optional.

Example configuration:

```json
{
  "targets": [
    {
      "url": "https://63.241.205.21",
      "name": "canary",
      "insecureSkipVerify": true
    }
  ]
}
```