### PR TITLE
Don't use MaxSampleTimeout if not provided

### DIFF
--- a/canary.go
+++ b/canary.go
@@ -112,7 +112,7 @@ func (c *Canary) startSensors() {
 			}
 		} else {
 			timeout := target.Interval
-			if timeout > c.Config.MaxSampleTimeout {
+			if c.Config.MaxSampleTimeout > 0 && timeout > c.Config.MaxSampleTimeout {
 				timeout = c.Config.MaxSampleTimeout
 			}
 


### PR DESCRIPTION
If MaxSampleTimeout is zero (ie not provided), do not force the target's interval to zero.  Doing so causes samples to immediately time out.