### PR TITLE
Ensure errors reading the body cause Ping to fail

### DIFF
--- a/pkg/sampler/sampler.go
+++ b/pkg/sampler/sampler.go
@@ -112,6 +112,9 @@ func Ping(target Target, timeout int) (sample Sample, err error) {
 		buf := make([]byte, contentLength)
 		for i := contentLength; i > 0; i = i - n {
 			n, err = r.Read(buf)
+			if err != nil {
+				return sample, err
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes the case where a timeout reading the body causes Ping() to loop forever.