### PR TITLE
Refactor sampler

### DIFF
--- a/cmd/canary/main.go
+++ b/cmd/canary/main.go
@@ -21,7 +21,7 @@ func usage() {
 }
 
 // builds the app configuration via ENV
-func getConfig() (c canary.Config, url string, err error) {
+func getConfig() (c canary.Config, url sampler.JsonURL, err error) {
 	flag.Usage = usage
 	flag.Parse()
 
@@ -51,7 +51,11 @@ func getConfig() (c canary.Config, url string, err error) {
 	if len(args) < 1 {
 		usage()
 	}
-	url = args[0]
+
+	u, err := sampler.NewJsonURL(args[0])
+	if err == nil {
+		url = *u
+	}
 
 	return
 }

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -38,7 +38,7 @@ func TestGetWithoutInterval(t *testing.T) {
 		t.Fatalf("expected name to be equal to 'canary', go %s", target.URL)
 	}
 
-	if target.URL != "http://www.canary.io" {
+	if target.URL.String() != "http://www.canary.io" {
 		t.Fatalf("expected URL to be equal to 'http://www.canary.io', got %s", target.URL)
 	}
 

--- a/pkg/sampler/http_util.go
+++ b/pkg/sampler/http_util.go
@@ -2,7 +2,6 @@ package sampler
 
 import (
 	"net/http"
-	"net/url"
 	"bufio"
 	"strings"
 	"fmt"
@@ -52,20 +51,15 @@ func parseHeaders(r *bufio.Reader) (http.Header, error) {
 }
 
 func genRequest(t Target) (string, error) {
-	u, err := url.Parse(t.URL)
-	if err != nil {
-		return "", err
-	}
-
 	// allow Host header to be set via t.RequestHeaders
 	// otherwise, use the host of the URL
 	hostHeader := t.RequestHeaders["Host"]
 	if hostHeader == "" {
-		hostHeader = u.Host
+		hostHeader = t.URL.Host
 	}
 
 	// our standard request
-	req := fmt.Sprintf("GET %s HTTP/1.1\r\n", u.RequestURI())
+	req := fmt.Sprintf("GET %s HTTP/1.1\r\n", t.URL.RequestURI())
 	req += fmt.Sprintf("Host: %s\r\n", hostHeader)
 
 	for k, v := range t.RequestHeaders {

--- a/pkg/sampler/http_util.go
+++ b/pkg/sampler/http_util.go
@@ -1,0 +1,81 @@
+package sampler
+
+import (
+	"net/http"
+	"net/url"
+	"bufio"
+	"strings"
+	"fmt"
+	"strconv"
+)
+
+func parseStatus(r *bufio.Reader) (int, error) {
+	statusLine, err := r.ReadString('\n')
+	if err != nil {
+		return 0, err
+	}
+
+	parts := strings.Split(statusLine, " ")
+	if len(parts) < 3 {
+		return 0, fmt.Errorf("'%s' is an invalid HTTP status response", strings.TrimSpace(statusLine))
+	}
+
+	status, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, err
+	}
+
+	return status, nil
+}
+
+func parseHeaders(r *bufio.Reader) (http.Header, error) {
+	headers := make(http.Header)
+	for {
+		line, err := r.ReadString('\n')
+
+		if err != nil {
+			return headers, nil
+		}
+
+		cleanLine := strings.TrimSpace(line)
+		if cleanLine == "" {
+			// end of headers
+			break
+		}
+
+		parts := strings.SplitN(cleanLine, ": ", 2)
+		if len(parts) == 2 {
+			headers.Add(parts[0], parts[1])
+		}
+	}
+	return headers, nil
+}
+
+func genRequest(t Target) (string, error) {
+	u, err := url.Parse(t.URL)
+	if err != nil {
+		return "", err
+	}
+
+	// allow Host header to be set via t.RequestHeaders
+	// otherwise, use the host of the URL
+	hostHeader := t.RequestHeaders["Host"]
+	if hostHeader == "" {
+		hostHeader = u.Host
+	}
+
+	// our standard request
+	req := fmt.Sprintf("GET %s HTTP/1.1\r\n", u.RequestURI())
+	req += fmt.Sprintf("Host: %s\r\n", hostHeader)
+
+	for k, v := range t.RequestHeaders {
+		if k != "Host" {
+			req += fmt.Sprintf("%s: %s\r\n", k, v)
+		}
+	}
+
+	// trailing newline
+	req += "\r\n"
+
+	return req, nil
+}

--- a/pkg/sampler/jsonurl.go
+++ b/pkg/sampler/jsonurl.go
@@ -1,0 +1,30 @@
+package sampler
+
+import "net/url"
+
+// The JsonURL type allows us to parse the URL from a JSON document at load
+// time, instead of when it's used (which could be multiple times)
+type JsonURL struct {
+	*url.URL
+}
+
+func NewJsonURL(str string) (u *JsonURL, err error) {
+	_url, err := url.Parse(str)
+	if err == nil {
+		u = &JsonURL{_url}
+	}
+
+	return
+}
+
+func (self *JsonURL) UnmarshalJSON(data []byte) (err error) {
+	// strip off leading and trailing double-quotes
+	tmp, err := NewJsonURL(string(data[1:len(data) - 1]))
+	
+	if err == nil {
+		*self = *tmp
+	}
+
+	return
+}
+

--- a/pkg/sampler/net_util.go
+++ b/pkg/sampler/net_util.go
@@ -1,0 +1,32 @@
+package sampler
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"crypto/tls"
+)
+
+func dial(t Target) (net.Conn, error) {
+	u, err := url.Parse(t.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	host, err := hostString(u)
+	if err != nil {
+		return nil, err
+	}
+
+	switch u.Scheme {
+	case "http":
+		return net.Dial("tcp", host)
+	case "https":
+		return tls.Dial("tcp", host, &tls.Config{
+			InsecureSkipVerify: t.InsecureSkipVerify,
+		})
+	default:
+		return nil, fmt.Errorf("unknown scheme '%s'", u.Scheme)
+	}
+}
+

--- a/pkg/sampler/net_util.go
+++ b/pkg/sampler/net_util.go
@@ -3,22 +3,16 @@ package sampler
 import (
 	"fmt"
 	"net"
-	"net/url"
 	"crypto/tls"
 )
 
 func dial(t Target) (net.Conn, error) {
-	u, err := url.Parse(t.URL)
+	host, err := hostString(&t.URL)
 	if err != nil {
 		return nil, err
 	}
 
-	host, err := hostString(u)
-	if err != nil {
-		return nil, err
-	}
-
-	switch u.Scheme {
+	switch t.URL.Scheme {
 	case "http":
 		return net.Dial("tcp", host)
 	case "https":
@@ -26,7 +20,6 @@ func dial(t Target) (net.Conn, error) {
 			InsecureSkipVerify: t.InsecureSkipVerify,
 		})
 	default:
-		return nil, fmt.Errorf("unknown scheme '%s'", u.Scheme)
+		return nil, fmt.Errorf("unknown scheme '%s'", t.URL.Scheme)
 	}
 }
-

--- a/pkg/sampler/sampler.go
+++ b/pkg/sampler/sampler.go
@@ -2,10 +2,6 @@ package sampler
 
 import (
 	"bufio"
-	"crypto/md5"
-	"crypto/tls"
-	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -14,25 +10,6 @@ import (
 	"strings"
 	"time"
 )
-
-type Target struct {
-	URL      string
-	Name     string
-	Interval int
-	// metadata
-	Tags               []string
-	Attributes         map[string]string
-	Hash               string
-	RequestHeaders     map[string]string
-	InsecureSkipVerify bool
-}
-
-func (t *Target) SetHash() {
-	jsonTarget, _ := json.Marshal(t)
-	hasher := md5.New()
-	hasher.Write(jsonTarget)
-	t.Hash = hex.EncodeToString(hasher.Sum(nil))
-}
 
 type Sample struct {
 	StatusCode      int
@@ -127,29 +104,6 @@ func Ping(target Target, timeout int) (sample Sample, err error) {
 	return
 }
 
-func dial(t Target) (net.Conn, error) {
-	u, err := url.Parse(t.URL)
-	if err != nil {
-		return nil, err
-	}
-
-	host, err := hostString(u)
-	if err != nil {
-		return nil, err
-	}
-
-	switch u.Scheme {
-	case "http":
-		return net.Dial("tcp", host)
-	case "https":
-		return tls.Dial("tcp", host, &tls.Config{
-			InsecureSkipVerify: t.InsecureSkipVerify,
-		})
-	default:
-		return nil, fmt.Errorf("unknown scheme '%s'", u.Scheme)
-	}
-}
-
 func hostString(u *url.URL) (string, error) {
 	// if our Host already has a port, bail out
 	if strings.Contains(u.Host, ":") {
@@ -166,73 +120,3 @@ func hostString(u *url.URL) (string, error) {
 	}
 }
 
-func parseStatus(r *bufio.Reader) (int, error) {
-	statusLine, err := r.ReadString('\n')
-	if err != nil {
-		return 0, err
-	}
-
-	parts := strings.Split(statusLine, " ")
-	if len(parts) < 3 {
-		return 0, fmt.Errorf("'%s' is an invalid HTTP status response", strings.TrimSpace(statusLine))
-	}
-
-	status, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return 0, err
-	}
-
-	return status, nil
-}
-
-func parseHeaders(r *bufio.Reader) (http.Header, error) {
-	headers := make(http.Header)
-	for {
-		line, err := r.ReadString('\n')
-
-		if err != nil {
-			return headers, nil
-		}
-
-		cleanLine := strings.TrimSpace(line)
-		if cleanLine == "" {
-			// end of headers
-			break
-		}
-
-		parts := strings.SplitN(cleanLine, ": ", 2)
-		if len(parts) == 2 {
-			headers.Add(parts[0], parts[1])
-		}
-	}
-	return headers, nil
-}
-
-func genRequest(t Target) (string, error) {
-	u, err := url.Parse(t.URL)
-	if err != nil {
-		return "", err
-	}
-
-	// allow Host header to be set via t.RequestHeaders
-	// otherwise, use the host of the URL
-	hostHeader := t.RequestHeaders["Host"]
-	if hostHeader == "" {
-		hostHeader = u.Host
-	}
-
-	// our standard request
-	req := fmt.Sprintf("GET %s HTTP/1.1\r\n", u.RequestURI())
-	req += fmt.Sprintf("Host: %s\r\n", hostHeader)
-
-	for k, v := range t.RequestHeaders {
-		if k != "Host" {
-			req += fmt.Sprintf("%s: %s\r\n", k, v)
-		}
-	}
-
-	// trailing newline
-	req += "\r\n"
-
-	return req, nil
-}

--- a/pkg/sampler/sampler.go
+++ b/pkg/sampler/sampler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -104,7 +103,7 @@ func Ping(target Target, timeout int) (sample Sample, err error) {
 	return
 }
 
-func hostString(u *url.URL) (string, error) {
+func hostString(u *JsonURL) (string, error) {
 	// if our Host already has a port, bail out
 	if strings.Contains(u.Host, ":") {
 		return u.Host, nil

--- a/pkg/sampler/sampler_test.go
+++ b/pkg/sampler/sampler_test.go
@@ -91,7 +91,7 @@ func TestSampleWithBodyTimeout(t *testing.T) {
 	defer ts.Close()
 
 	target := Target{
-		URL: ts.URL,
+		URL: parseUrl(ts.URL),
 	}
 
 	_, err := Ping(target, int(timeout / time.Second))

--- a/pkg/sampler/sampler_test.go
+++ b/pkg/sampler/sampler_test.go
@@ -9,6 +9,12 @@ import (
 	"strings"
 )
 
+func parseUrl(str string) JsonURL {
+	u, _ := NewJsonURL(str)
+	
+	return *u
+}
+
 func TestSample(t *testing.T) {
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "ok")
@@ -17,7 +23,7 @@ func TestSample(t *testing.T) {
 	defer ts.Close()
 
 	target := Target{
-		URL: ts.URL,
+		URL: parseUrl(ts.URL),
 	}
 
 	sample, err := Ping(target, 1)
@@ -43,7 +49,7 @@ func TestSampleWithHeaders(t *testing.T) {
 	defer ts.Close()
 
 	target := Target{
-		URL: ts.URL,
+		URL: parseUrl(ts.URL),
 	}
 
 	sample, err := Ping(target, 1)
@@ -111,7 +117,7 @@ func TestSampleWithCanonicalizedHeaderName(t *testing.T) {
 	defer ts.Close()
 
 	target := Target{
-		URL: ts.URL,
+		URL: parseUrl(ts.URL),
 	}
 
 	sample, err := Ping(target, 1)
@@ -138,7 +144,7 @@ func TestSampleWithMissingHeader(t *testing.T) {
 	defer ts.Close()
 
 	target := Target{
-		URL: ts.URL,
+		URL: parseUrl(ts.URL),
 	}
 
 	sample, err := Ping(target, 1)
@@ -167,7 +173,7 @@ func TestSampleWithRequestHeaders(t *testing.T) {
 	defer ts.Close()
 
 	target := Target{
-		URL: ts.URL,
+		URL: parseUrl(ts.URL),
 		RequestHeaders: map[string]string{
 			"X-Foo": "bar",
 		},
@@ -191,7 +197,7 @@ func TestSampleWithRequestHeaders(t *testing.T) {
 func TestGenRequest(t *testing.T) {
 	expected := "GET / HTTP/1.1\r\nHost: canary.io\r\n\r\n"
 	target := Target{
-		URL: "http://canary.io",
+		URL: parseUrl("http://canary.io"),
 	}
 
 	req, err := genRequest(target)
@@ -212,7 +218,7 @@ func TestGenRequestWithCustomHost(t *testing.T) {
 	headers["Host"] = "canary.io"
 
 	target := Target{
-		URL:            "http://192.168.1.1",
+		URL:            parseUrl("http://192.168.1.1"),
 		RequestHeaders: headers,
 	}
 

--- a/pkg/sampler/target.go
+++ b/pkg/sampler/target.go
@@ -1,0 +1,26 @@
+package sampler
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+)
+
+type Target struct {
+	URL      string
+	Name     string
+	Interval int
+	// metadata
+	Tags               []string
+	Attributes         map[string]string
+	Hash               string
+	RequestHeaders     map[string]string
+	InsecureSkipVerify bool
+}
+
+func (t *Target) SetHash() {
+	jsonTarget, _ := json.Marshal(t)
+	hasher := md5.New()
+	hasher.Write(jsonTarget)
+	t.Hash = hex.EncodeToString(hasher.Sum(nil))
+}

--- a/pkg/sampler/target.go
+++ b/pkg/sampler/target.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Target struct {
-	URL      string
+	URL      JsonURL
 	Name     string
 	Interval int
 	// metadata

--- a/pkg/stdoutpublisher/publisher_test.go
+++ b/pkg/stdoutpublisher/publisher_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 func ExamplePublisher_Publish() {
+	url, _ := sampler.NewJsonURL("http://www.canary.io")
 	target := sampler.Target{
-		URL: "http://www.canary.io",
+		URL: *url,
 	}
 
 	t1, _ := time.Parse(time.RFC3339, "2014-12-28T00:00:00Z")


### PR DESCRIPTION
This got a little out of control, sorry about that.  I tried to at least make the individual commits relatively self-contained.

* `sampler.go` was getting kind of dense; I split it into separate files on rough type/functionality boundaries
* I made `Target.URL` a `JsonURL` type that can be deserialized directly from JSON. This will cause invalid URLs to fail manifest parsing early, as opposed to on every invocation of `Ping`.  It also ensures that the URL is only parsed once, which avoids having to pass around a parsed URL instance when needed in multiple places.
* The connection to the remote server did not honor the Ping timeout
* The IP address of the remote server was only captured if a connection was successful
* The time to resolve the IP address is now captured