### PR TITLE
Specify ServerName when using TLS

### DIFF
--- a/pkg/sampler/net_util.go
+++ b/pkg/sampler/net_util.go
@@ -35,7 +35,7 @@ func resolveIPAddr(host string, deadline time.Time) (net.IP, error) {
 	}
 }
 
-func dial(scheme string, addr string, deadline time.Time, insecure bool) (net.Conn, error) {
+func dial(scheme string, addr string, serverName string, deadline time.Time, insecure bool) (net.Conn, error) {
 	dialer := &net.Dialer{
 		Deadline: deadline,
 	}
@@ -45,6 +45,7 @@ func dial(scheme string, addr string, deadline time.Time, insecure bool) (net.Co
 		return dialer.Dial("tcp", addr)
 	case "https":
 		return tls.DialWithDialer(dialer, "tcp", addr, &tls.Config{
+			ServerName:         serverName,
 			InsecureSkipVerify: insecure,
 		})
 	default:

--- a/pkg/sampler/sampler.go
+++ b/pkg/sampler/sampler.go
@@ -62,7 +62,7 @@ func Ping(target Target, timeout int) (sample Sample, err error) {
 	sample.TimeToResolveIP = time.Now()
 	sample.RemoteAddr = ip
 	
-	conn, err := dial(target.URL.Scheme, ip.String() + ":" + port, deadline, target.InsecureSkipVerify)
+	conn, err := dial(target.URL.Scheme, ip.String() + ":" + port, hostname, deadline, target.InsecureSkipVerify)
 	if err != nil {
 		err = fmt.Errorf("connecting: %s", err)
 		return

--- a/pkg/sampler/sampler.go
+++ b/pkg/sampler/sampler.go
@@ -62,7 +62,13 @@ func Ping(target Target, timeout int) (sample Sample, err error) {
 	sample.TimeToResolveIP = time.Now()
 	sample.RemoteAddr = ip
 	
-	conn, err := dial(target.URL.Scheme, ip.String() + ":" + port, hostname, deadline, target.InsecureSkipVerify)
+	// ipv6 addresses must be wrapped in brackets
+	ipStr := ip.String()
+	if ip.To4() == nil {
+		ipStr = "[" + ipStr + "]"
+	}
+	
+	conn, err := dial(target.URL.Scheme, ipStr + ":" + port, hostname, deadline, target.InsecureSkipVerify)
 	if err != nil {
 		err = fmt.Errorf("connecting: %s", err)
 		return
@@ -77,9 +83,8 @@ func Ping(target Target, timeout int) (sample Sample, err error) {
 	if err != nil {
 		return
 	}
-	fmt.Fprint(
-		conn,
-		req)
+
+	fmt.Fprint(conn, req)
 
 	r := bufio.NewReader(conn)
 

--- a/pkg/sampler/sampler_test.go
+++ b/pkg/sampler/sampler_test.go
@@ -276,5 +276,21 @@ func TestGenRequestWithCustomHost(t *testing.T) {
 	if req != expected {
 		t.Fatalf("Expected request to look like:\n%s\n but got:\n%s\n", expected, req)
 	}
-
 }
+
+func TestConnectSecurelyWithVerify(t *testing.T) {
+	target := Target{
+		URL: parseUrl("https://www.google.com/"),
+		InsecureSkipVerify: false,
+	}
+
+	sample, err := Ping(target, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if sample.StatusCode != 200 {
+		t.Fatalf("Expected sampleStatus == 200, but got %d\n", sample.StatusCode)
+	}
+}
+


### PR DESCRIPTION
Without this, the user's forced to set InsecureSkipVerify to true for the target in the manifest, as we're now connecting directly to the IP address we resolved ourselves.  The error the client received was:

    connecting: x509: cannot validate certificate for 74.125.226.19 because it doesn't contain any IP SANs