### PR TITLE
Support the MAX_RELOAD_FAILURES environment variable in canaryd to handle temporary errors when reloading the defined MANIFEST_URL via AUTO_RELOAD_INTERVAL

### DIFF
--- a/cmd/canaryd/README.md
+++ b/cmd/canaryd/README.md
@@ -17,6 +17,7 @@ $ go get github.com/canaryio/canary/cmd/canaryd
 * `PUBLISHERS` - an explicit list of pubilshers to enable, defaulting to `stdout`
 * `DEFAULT_MAX_TIMEOUT` - The max timeout value for any target. Actual timeout will be this value, or the interval if lower.
 * `AUTO_RELOAD_INTERVAL` - The value (in seconds, as a floating point string) to query MANIFEST_URL for a potential manifest reload.See the Manifest reloading section for more information.
+* `MAX_RELOAD_FAILURES` - The maximum number of allowed consecutive manifest reload failures combined with `AUTO_RELOAD_INTERVAL` (defaulting to 5). This parameter is specified as an integer and enables canaryd to handle if the `MANIFEST_URL` backend is temporarily unavailable. If a failure is caught before this threshold, then no changes are made to the currently executing manifest. If this threshold is reached, canaryd will exit with status 1 and an informational error about what caused the error. 
 * `DEFAULT_SAMPLE_INTERVAL` - interval rate (in seconds) for targets without a defined interval value, defaults to 1 second.
 * `RAMPUP_SENSORS` - When set to 'yes', configure a delayed start for each target sensors, with the delay based on an even division of DEFAULT_SAMPLE_INTERVAL by the target index. This assists with performance for large numbers of targets. This will cause all targets to be measured within one full DEFAULT_SAMPLE_INTERVAL when starting.
 

--- a/cmd/canaryd/main.go
+++ b/cmd/canaryd/main.go
@@ -60,6 +60,18 @@ func getConfig() (c canary.Config, err error) {
 		c.ReloadInterval = duration
 	}
 
+	if err == nil {
+		maxReloadFailures := os.Getenv("MAX_RELOAD_FAILURES")
+		if maxReloadFailures == "" {
+			maxReloadFailures = "5"
+		}
+
+		c.MaxReloadFailures, err = strconv.Atoi(maxReloadFailures)
+		if err != nil {
+			err = fmt.Errorf("MAX_RELOAD_FAILURES is not a valid integer")
+		}
+	}
+
 	// Set RampupSensors if RAMPUP_SENSORS is set to 'yes'
 	rampUp := os.Getenv("RAMPUP_SENSORS")
 	if rampUp == "yes" {

--- a/config.go
+++ b/config.go
@@ -7,5 +7,6 @@ type Config struct {
 	DefaultSampleInterval int
 	RampupSensors         bool
 	ReloadInterval        time.Duration
+	MaxReloadFailures     int
 	MaxSampleTimeout      int
 }


### PR DESCRIPTION
I am posting this PR because the automatic reload feature I previously added in #34 is a bit fragile if the `MANIFEST_URL` is unavailable. For example if the manifest url is unavailable for any attempted reload, the canaryd process hard fails. It is desirable to have some resiliency against transient connectivity errors for the defined `MANIFEST_URL`

This patch adds error handling around failed manifest reloads, in which a failure is ignored (within the current Ticker for reloads) upto a max failure count (default of 5, for lack of a better value). The number of failed reloads is overridden via the `MAX_RELOAD_FAILURES` integer environment variable to allow tuning how many consecutive failures are allowed if the default of 5 is not desired.

I am not dead set on 5 as the default, and can easily change this to one (to maintain compatibility with current behavior) or any other suggested value.

This PR does not affect the behavior around the initial manifest load where canaryd fails if the manifest is not able to be loaded the first time.

Example:

Serving a manifest from a simple sinatra app locally:

```
jmeichle@jkm-ThinkPad-T440s:~/go/src/github.com/canaryio/canary/cmd/canaryd$ curl http://localhost:4567/manifest
{"targets":[{"url":"http://www.canary.io","name":"canary"},{"url":"https://www.simple.com/","name":"simple"},{"url":"https://www.heroku.com/","name":"heroku"},{"url":"https://github.com","name":"github"}]}
```

Starting canary, then turning the sinatra backend off has canary attempt to reload upto the default of 5 times (at the `AUTO_RELOAD_INTERVAL`) then it fails:

```
jmeichle@jkm-ThinkPad-T440s:~/go/src/github.com/canaryio/canary/cmd/canaryd$ RAMPUP_SENSORS=yes AUTO_RELOAD_INTERVAL=2 DEFAULT_SAMPLE_INTERVAL=4 MANIFEST_URL=http://localhost:4567/manifest ./canaryd 
2016-06-02T00:45:01-04:00 http://www.canary.io 200 207.015163 true 1 
2016-06-02T00:45:02-04:00 https://www.simple.com/ 200 255.164281 true 1 
2016-06-02T00:45:04-04:00 https://github.com 200 147.521657 true 1 
2016-06-02T00:45:05-04:00 http://www.canary.io 200 225.776839 true 2 
2016-06-02T00:45:06-04:00 https://www.simple.com/ 200 280.399879 true 2 
2016-06-02T00:45:07-04:00 https://www.heroku.com/ 0 4000.262701 false 1 'resolving IP for www.heroku.com: dns timeout'
2016-06-02T00:45:08-04:00 https://github.com 200 130.202191 true 2 
2016-06-02T00:45:08-04:00 https://www.heroku.com/ 200 1183.514966 true 1 
2016-06-02T00:45:09-04:00 http://www.canary.io 200 115.705698 true 3 
2016-06-02T00:45:10-04:00 https://www.simple.com/ 200 294.034447 true 3 
2016-06-02T00:45:11-04:00 https://www.heroku.com/ 200 193.071735 true 2 
2016-06-02T00:45:12-04:00 https://github.com 200 229.072061 true 3 
2016/06/02 00:45:13 canary: Error reloading manifest (attempt: 5/5 at a 2s interval): Get http://localhost:4567/manifest: dial tcp 127.0.0.1:4567: connection refused
```

It also retries the `MANIFEST_URL` if the backend gives an invalid JSON response (such as restarting the manifest server where /manifest returns a 404): 

```
jmeichle@jkm-ThinkPad-T440s:~/go/src/github.com/canaryio/canary/cmd/canaryd$ RAMPUP_SENSORS=yes AUTO_RELOAD_INTERVAL=2 DEFAULT_SAMPLE_INTERVAL=4 MANIFEST_URL=http://localhost:4567/manifest ./canaryd 
2016-06-02T00:45:26-04:00 http://www.canary.io 200 198.408920 true 1 
2016-06-02T00:45:28-04:00 https://www.simple.com/ 200 337.989189 true 1 
2016-06-02T00:45:29-04:00 https://www.heroku.com/ 200 344.219247 true 1 
2016-06-02T00:45:30-04:00 https://github.com 200 272.484900 true 1 
2016-06-02T00:45:30-04:00 http://www.canary.io 200 80.147036 true 2 
2016-06-02T00:45:31-04:00 https://www.simple.com/ 200 178.927806 true 2 
2016-06-02T00:45:32-04:00 https://www.heroku.com/ 200 201.389417 true 2 
2016-06-02T00:45:33-04:00 https://github.com 200 153.466728 true 2 
2016-06-02T00:45:34-04:00 http://www.canary.io 200 108.095606 true 3 
2016-06-02T00:45:36-04:00 https://www.simple.com/ 200 227.737043 true 3 
2016-06-02T00:45:36-04:00 https://www.heroku.com/ 200 173.622606 true 3 
2016-06-02T00:45:37-04:00 https://github.com 200 139.147897 true 3 
2016/06/02 00:45:38 canary: Error reloading manifest (attempt: 5/5 at a 2s interval): invalid character '<' looking for beginning of value
```

The number of failures is tuneable via the `MAX_RELOAD_FAILURES` environment variable:

```
jmeichle@jkm-ThinkPad-T440s:~/go/src/github.com/canaryio/canary/cmd/canaryd$ MAX_RELOAD_FAILURES=2 RAMPUP_SENSORS=yes AUTO_RELOAD_INTERVAL=2 DEFAULT_SAMPLE_INTERVAL=4 MANIFEST_URL=http://localhost:4567/manifest ./canaryd 
2016-06-02T00:48:35-04:00 http://www.canary.io 200 124.009352 true 1 
2016-06-02T00:48:36-04:00 https://www.simple.com/ 200 313.901080 true 1 
2016-06-02T00:48:37-04:00 https://www.heroku.com/ 200 226.429035 true 1 
2016-06-02T00:48:38-04:00 https://github.com 200 147.233354 true 1 
2016/06/02 00:48:39 canary: Error reloading manifest (attempt: 2/2 at a 2s interval): Get http://localhost:4567/manifest: dial tcp 127.0.0.1:4567: connection refused
```
